### PR TITLE
Release 1.6.0

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,6 +4,6 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  cerner_splunk (1.6.0)
+  cerner_splunk (1.7.0)
     ulimit (~> 0.3.2)
   ulimit (0.3.2)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache 2.0'
 description      'Installs/Configures Splunk Servers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.6.0'
+version          '1.7.0'
 
 depends          'ulimit', '~> 0.3.2'
 

--- a/project.yml
+++ b/project.yml
@@ -1,7 +1,7 @@
 name: Splunk Cookbook
 group_id: com.cerner.opsinfra
 artifact_id: cerner_splunk
-version: 1.6.0
+version: 1.7.0.SNAPSHOT
 doc: tomdoc
 package:
   type: cookbook
@@ -13,7 +13,7 @@ jira:
   component: 12916
 github:
   project_url: https://github.com/cerner/cerner_splunk
-  previous_version: 1.5.0
+  previous_version: 1.6.0
 snapshot_repository:
   id: semantic-snapshot
   url: http://repo.snapshot.cerner.corp/nexus/content/repositories/semantic-snapshot/


### PR DESCRIPTION
Proposed Tag Text:

``` text
"Because you can't always blame Canada"

cerner_splunk Cookbook Release 1.6.0
- Support for Windows Forwarders
- Support for arbitrary 'app' configuration
- Beginnings of an open source contribution process.
```

Also available for review is the comparison from the last tag to the current stable: https://github.com/cerner/cerner_splunk/compare/1.5.0...e37500d731f160741cb2a3f360c83cca6ee80f7e

And all issues and pull requests toward this milestone:
https://github.com/cerner/cerner_splunk/issues?q=milestone%3Av1.6.0
