### PR TITLE
Fixes #21 use comparison for platform based attributes

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -2,7 +2,7 @@
 
 default[:splunk][:node_type] = nil
 
-if platform_family?('windows')
+if node['platform_family'] == 'windows'
   default[:splunk][:external_config_directory] = "#{ENV['PROGRAMDATA']}/splunk"
 else
   default[:splunk][:external_config_directory] = '/etc/splunk'

--- a/attributes/_user_management.rb
+++ b/attributes/_user_management.rb
@@ -1,7 +1,7 @@
 # coding: UTF-8
 
 # Do not override these
-if platform_family?('windows')
+if node['platform_family'] == 'windows'
   default[:splunk][:user] = 'SYSTEM'
   default[:splunk][:group] = 'SYSTEM'
 else


### PR DESCRIPTION
Uses a comparison against the node attribute instead of platform_family? as that method is not available to attributes in chef 10. Fixes #21 
