### PR TITLE
Fix rubocop brace error with Rubocop 0.28

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,5 @@ PerceivedComplexity:
 Metrics/AbcSize:
   Enabled: false
 
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent


### PR DESCRIPTION
Rubocop 0.28 [was released yesterday](https://github.com/bbatsov/rubocop/releases/tag/v0.28.0) and as a result introduced a warning about braces around a trailing hash argument. But bbatsov/rubocop#801 introduced a parameter that would follow what I view to be the expected behavior.
