### PR TITLE
Updates for chef 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ language: ruby
 bundler_args: --without deployment
 rvm:
 - 1.9.3
-- 2.1.1
+- 2.1.4
 script:
 - bundle exec rubocop

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,7 @@ Vagrant.configure('2') do |config|
 
     cfg.vm.provision :shell, inline: <<-'SCRIPT'.gsub(/^\s+/, '')
       yum -y install git
-      rpm -q chefdk || rpm -Uvh https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chefdk-0.3.0-1.x86_64.rpm
+      rpm -q chefdk || rpm -Uvh https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chefdk-0.3.5-1.x86_64.rpm
     SCRIPT
 
     if ENV['KNIFE_ONLY']

--- a/libraries/splunk_template.rb
+++ b/libraries/splunk_template.rb
@@ -5,6 +5,7 @@
 # HWR for configuring Splunk.
 
 require 'chef/resource/template'
+require 'chef/provider/template'
 require 'chef/mixin/securable'
 require_relative 'lwrp'
 
@@ -15,7 +16,9 @@ class Chef
       include Chef::Mixin::Securable
       extend CernerSplunk::LWRP::DelayableAttribute unless defined? delayable_attribute
 
-      provides :splunk_template, on_platforms: :all
+      use_provider_resolver = defined?(Chef::ProviderResolver) == 'constant' && Chef::ProviderResolver.class == Class
+
+      provides :splunk_template, (use_provider_resolver ? {} : { on_platforms: :all })
 
       # rubocop:disable MethodLength
       def initialize(name, run_context = nil)
@@ -29,6 +32,7 @@ class Chef
         user node[:splunk][:user]
         group node[:splunk][:group]
         mode '0600'
+        provider Chef::Provider::Template
         # atomic_update in this instance causes issues on windows similar to
         # https://tickets.opscode.com/browse/CHEF-4625
         # However, atomic_update from a chef provided template resource


### PR DESCRIPTION
Fixes #15 

This seems to be the set of changes needed for the cookbook to work on Chef 12. 

Chef 12's RFC is [on the chef-rfc repo](https://github.com/opscode/chef-rfc/blob/70d848f45b0f34d201585abc1740f1a6f85ba616/rfc015-chef-12.md). Despite the statement there, it seems that Chef 12 shipped with Ruby 2.1.4p265 (not 2.1.2). 

The thing we were primarily running into with #15 however was [the changes around how provider resolution is performed](https://github.com/opscode/chef/blob/12.0.0/RELEASE_NOTES.md#resource-and-provider-resolution-changes). Chef deprecated the existing massive map binding in favor of the ProviderResolver (to get around a certain class of resolution issues). As a result we were no longer binding to the Template provider for our resource, but by adding that binding explicitly we get around that issue.
