### PR TITLE
Fix #17 - restart the splunk service when the splunk group membership changes

### DIFF
--- a/recipes/_user_management.rb
+++ b/recipes/_user_management.rb
@@ -29,6 +29,7 @@ groups_to_add.uniq.each do |grp|
     group_name grp
     members [node['splunk']['user']]
     action :manage
+    notifies :restart, 'service[splunk]'
   end
 end
 
@@ -41,6 +42,7 @@ if Chef::Resource::Group.instance_methods.include?(:excluded_members)
       group_name grp
       excluded_members [node['splunk']['user']]
       action :manage
+      notifies :restart, 'service[splunk]'
     end
   end
 else


### PR DESCRIPTION
Added in notifications so that if the splunk group memberships change the service will be restarted. I believe this will fix #17 
