### PR TITLE
Fixes #26 - declare the version for the package resource

### DIFF
--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -53,8 +53,9 @@ remote_file splunk_file do
   only_if(&manifest_missing)
 end
 
-package node['splunk']['package']['name'] do
+package node['splunk']['package']['base_name'] do
   source splunk_file
+  version "#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"
   provider node['splunk']['package']['provider']
   only_if(&manifest_missing)
   if platform_family?('windows')


### PR DESCRIPTION
Explicitly declare the version for the package instead of including it in the package name.
