### PR TITLE
Release 1.7.0

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,6 +4,6 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  cerner_splunk (1.7.0)
+  cerner_splunk (1.8.0)
     ulimit (~> 0.3.2)
   ulimit (0.3.2)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache 2.0'
 description      'Installs/Configures Splunk Servers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.7.0'
+version          '1.8.0'
 
 depends          'ulimit', '~> 0.3.2'
 

--- a/project.yml
+++ b/project.yml
@@ -1,7 +1,7 @@
 name: Splunk Cookbook
 group_id: com.cerner.opsinfra
 artifact_id: cerner_splunk
-version: 1.7.0.SNAPSHOT
+version: 1.7.0
 doc: tomdoc
 package:
   type: cookbook

--- a/project.yml
+++ b/project.yml
@@ -1,7 +1,7 @@
 name: Splunk Cookbook
 group_id: com.cerner.opsinfra
 artifact_id: cerner_splunk
-version: 1.7.0
+version: 1.8.0.SNAPSHOT
 doc: tomdoc
 package:
   type: cookbook
@@ -13,7 +13,7 @@ jira:
   component: 12916
 github:
   project_url: https://github.com/cerner/cerner_splunk
-  previous_version: 1.6.0
+  previous_version: 1.7.0
 snapshot_repository:
   id: semantic-snapshot
   url: http://repo.snapshot.cerner.corp/nexus/content/repositories/semantic-snapshot/


### PR DESCRIPTION
Proposed Tag Text:
```text
"Finding your faults just like mom"

cerner_splunk Cookbook Release 1.7.0
- Fixes to Chef 10 support
- Addition of Chef 12 support
- Service restart for system user group changes
- Improvements to Cleanup of former cookbook (including addition of skip option)
- Initial Foodcritic application
- Other minor fixes
```

Also available for review is the comparison from the last tag to the current stable: https://github.com/cerner/cerner_splunk/compare/1.6.0... ac7e587d861c3903878554f6eea4734896b3b606

And all issues and pull requests toward this milestone:
https://github.com/cerner/cerner_splunk/issues?q=milestone%3Av1.7.0