### PR TITLE
Fixes #3 - Fix splat operator in authorize.conf generation

### DIFF
--- a/recipes/_configure_authentication.rb
+++ b/recipes/_configure_authentication.rb
@@ -71,7 +71,7 @@ when 'Scripted'
 when 'LDAP'
   strategies = hash.delete('LDAP_strategies')
   fail 'LDAP_strategies required for LDAP authentication' unless strategies
-  strategies = [*strategies]
+  strategies = [strategies] unless strategies.is_a? Array
   strategies = strategies.collect do |strategy|
     hash =
       case strategy

--- a/vagrant_repo/data_bags/cerner_splunk/authnz-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/authnz-vagrant.json
@@ -2,13 +2,13 @@
   "id": "authnz-vagrant",
   "authn": {
     "search_head": {
-      "LDAP_strategies": [{
+      "LDAP_strategies": {
         "bag": ":ldap",
         "roleMap" : {
           "opsinfra": "splunk_dev_opsinfra",
           "admin": "DevOps_SuperAdmins"
         }
-      }]
+      }
     },
     "server": "search_head",
     "": {


### PR DESCRIPTION
This PR is for fixing Issue #3. 

There are two other places where the splat operator is in use, but in these cases, using the splat seems to be the correct behavior:
* [libraries/splunk_app.rb](https://github.com/cerner/cerner_splunk/blob/1.7.0/libraries/splunk_app.rb#L139) - role will either be a String or an Array 
* [vagrant_repo/cookbooks/cerner_splunk_test/templates/default/access.log.erb](https://github.com/cerner/cerner_splunk/blob/1.7.0/vagrant_repo/cookbooks/cerner_splunk_test/templates/default/access.log.erb) - This is an expansion of an explicit range in the test cookbook.

