### PR TITLE
Fixes #37 - Install apps via tarballs 

### DIFF
--- a/docs/databags.md
+++ b/docs/databags.md
@@ -93,7 +93,10 @@ An apps hash is a contextual (see above) Hash, part of a plaintext data bag item
 * `['bag']` - A string that points to an externalized Apps Hash in which all keys (except this one) are valid. 
 * `[app]` - The name of an app to manage (disk name)
 * `[app]['remove']` - If true, remove this app instead of creating / managing  (default - false)
-* `[app]['local']` - If true, manage files in the local directories instead of the "default" (default-false)
+* `[app]['local']` - If true, manage `[app]['files']` defined files and `[app]['permissions']` defined metadata in the "local" directory and "local.meta" instead of the "default" directory and "default.meta" (default - false, but forced true if download-url is specified)
+* `[app]['download']` - Information for downloading an app
+* `[app]['download']['url']` - URL of where to download the app .tar.gz or .spl file. Archive is expected to contain a top-level directory with name matching 'app' attribute above.
+* `[app]['download']['version']` - Expected [version number][app.conf] (if any) used to determine if a new app should be downloaded.
 * `[app]['files']` - Hash of files to manage under the "default" or "local" directory.
 * `[app]['files'][filename]` - Contents of a particular file to manage. It can take 3 values, a hash of stanzas -> key-value pairs (then written with the splunk template), a string (written as is), or nil / false (deleted). If the hash or string is empty, the file is also deleted.
 * `[app]['permissions']` - Hash of permissions to manage for the app.
@@ -115,3 +118,4 @@ Docs Navigation
 [authentication.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Authenticationconf
 [alert-actions.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Alert-actionsconf
 [default.meta]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Defaultmetaconf
+[app.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/appconf

--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -27,6 +27,22 @@ module CernerSplunk
       end
     end
   end
+
+  # Utility Class to parse app version strings
+  class AppVersion
+    def initialize(version)
+      @version = version.chomp.empty? ? nil : version.chomp unless version.nil?
+      @base, @prerelease = @version.split(' ', 2) unless @version.nil?
+      @type = @prerelease.nil? ? :base : :prerelease unless @version.nil?
+    end
+
+    attr_reader :version, :base, :prerelease, :type
+    alias_method :to_s, :version
+
+    def ==(other)
+      version == other.version
+    end
+  end
 end
 
 class Chef

--- a/libraries/tarball.rb
+++ b/libraries/tarball.rb
@@ -1,0 +1,157 @@
+# coding: UTF-8
+#
+# Cookbook Name:: cerner_splunk
+# File Name:: tarball.rb
+#
+# Methods for working with data from a tarball.
+
+require 'rubygems/package'
+require 'zlib'
+require 'fileutils'
+
+module CernerSplunk
+  # Utility class to encapsulate operations on tar.gz files
+  # Mad Props to http://stackoverflow.com/a/19139114/504685
+  class TarBall
+    def initialize(file_name, options = {})
+      @data = []
+      @clean_proc = Remover.new(@data)
+      ObjectSpace.define_finalizer(self, @clean_proc)
+      @file_name = @data[0] = file_name
+      @reader = @data[1] =  Gem::Package::TarReader.new(Zlib::GzipReader.open @file_name)
+      @prefix = options[:prefix]
+      @options = options
+    end
+
+    attr_reader :prefix
+
+    def get_file(name)
+      data = []
+      target_path = @prefix.nil? ? name : "#{@prefix}/#{name}"
+      iterate file: proc { |path, entry| data << entry.read if path == target_path }, other: proc {}
+      fail "Multiple entries for #{target_path} found in #{@file_name}" if data.size > 1
+      data.first
+    end
+
+    def extract(extract_dir)
+      file_handler = proc do |path, entry|
+        target = "#{extract_dir}/#{path}"
+        make_dirs extract_dir, path
+        File.open(target, 'wb') { |f| f.print entry.read }
+        FileUtils.chmod entry.header.mode, target
+        FileUtils.chown @options[:user], @options[:group], target
+      end
+
+      dir_handler = proc do |path, entry|
+        target = "#{extract_dir}/#{path}"
+        make_dirs extract_dir, path, true
+        FileUtils.chmod entry.header.mode, target
+      end
+
+      symlink_handler = proc do |path, entry, other = {}|
+        target = "#{extract_dir}/#{path}"
+        make_dirs extract_dir, path
+        File.unlink target if File.exist? target
+        File.symlink other[:linkname], target
+        FileUtils.chmod entry.header.mode, target
+        FileUtils.chown @options[:user], @options[:group], target
+      end
+
+      iterate file: file_handler, directory: dir_handler, symlink: symlink_handler
+    end
+
+    # Count the number of (qualified) entries in the tarball where the return value
+    # of the corresponding callback applied to each entry in the tarfile is truthy.
+    # With no arguments, counts the number of qualified entries
+    # If called with a block (only), the block is the callback to for every entry.
+    # If called with a map, invoke the appropriate callback for each corresponding entry.
+    # See iterate for details on how callbacks are invoked.
+    def count(callbacks = {}, &other)
+      callbacks = { other: other } if other && callbacks.empty?
+      i = 0
+      # Wrap each callback such that if it's truthy, we increment our counter.
+      hsh = callbacks.each_with_object({}) { |(k, v), h| h[k] = proc { |*args| i += 1 if v.call(args) } }
+      hsh[:other] = proc { i += 1 } if hsh.empty?
+      hsh[:other] = proc {} unless hsh[:other]
+      iterate hsh
+      i
+    end
+
+    def num_files
+      count file: proc { true }
+    end
+
+    def make_dirs(extract_dir, path, all = false)
+      segments = path.split('/')
+      segments = segments[0...-1] unless all
+      segments.each_with_object(extract_dir.dup) do |segment, target|
+        target << "/#{segment}"
+        FileUtils.mkdir target unless File.directory? target
+        FileUtils.chown @options[:user], @options[:group], target
+      end
+    end
+
+    # Iterate over the entries of the tarfile, and invoke the corresponding callback with each entry.
+    # We handle the LongFileName and LongSymLink entries as found (no callbacks, but they change values sent with other callbacks)
+    # If a prefix is set, we skip any entry whose path does not start with the prefix
+    # The callbacks is a hash of Symbol or String mapped to Proc
+    # callbacks with keys of :file, :directory, or :symlink would be invoked for file, directory, or symlink entries
+    # callbacks with string keys, would be invoked if the header typeflag matches (in the absense of :file, :directory, or :symlink callbacks)
+    # callbacks with a key of :other would be invoked if no other callback is found
+    # If no callback at all is found for the current item, then we fail.
+    def iterate(callbacks = {}) # rubocop:disable PerceivedComplexity, CyclomaticComplexity
+      @reader.rewind
+      long_path = nil
+      long_link = nil
+      @reader.each do |entry|
+        case entry.header.typeflag
+        when 'L' # LongFileName
+          long_path = entry.read.strip
+        when 'K' # LongSymLink
+          long_link = entry.read.strip
+        else
+          path = long_path && long_path.start_with?(entry.full_name) ? long_path : entry.full_name
+          linkname = long_link && long_link.start_with?(entry.header.linkname) ? long_link : entry.header.linkname
+
+          # Determine which callback to invoke based on the typeflag
+          callback = callbacks[:file] if entry.header.typeflag == '0'
+          callback ||= callbacks[:directory] if entry.header.typeflag == '5'
+          callback ||= callbacks[:symlink] if entry.header.typeflag == '2'
+          callback ||= callbacks[entry.header.typeflag]
+          callback ||= callbacks[:other]
+
+          if @prefix.nil? || path.start_with?("#{@prefix}/")
+            fail "Unsupported typeflag #{entry.header.typeflag} for path #{path}" unless callback
+
+            callback.call path, entry, linkname: linkname
+          end
+
+          long_path = nil
+          long_link = nil
+        end
+      end
+    end
+
+    def close
+      @reader.close
+      @data[0] = @file_name = nil
+      @data[1] = @reader = nil
+      ObjectSpace.undefine_finalizer(self)
+    end
+
+    # :stopdoc:
+    # This pattern came from the Tempfile class in Ruby.
+    class Remover
+      def initialize(data)
+        @pid = $PID
+        @data = data
+      end
+
+      def call(*)
+        return if @pid != $PID
+        _, reader = *@data
+        reader.close if reader
+      end
+    end
+  end
+end

--- a/recipes/_configure_apps.rb
+++ b/recipes/_configure_apps.rb
@@ -17,9 +17,13 @@ bag_bag = CernerSplunk::DataBag.load(cluster_bag['bag']) || {}
 apps = CernerSplunk::SplunkApp.merge_hashes(bag_bag, cluster_bag, attributes_bag, attributes)
 
 apps.each do |app_name, app_data|
+  download_data = app_data['download'] || {}
+
   splunk_app app_name do
     apps_dir "#{node['splunk']['home']}/etc/apps"
     action app_data['remove'] ? :remove : :create
+    url download_data['url']
+    version download_data['version']
     local app_data['local']
     files app_data['files']
     permissions app_data['permissions']

--- a/vagrant_repo/apps/my_app/default/app.conf
+++ b/vagrant_repo/apps/my_app/default/app.conf
@@ -1,0 +1,13 @@
+[launcher]
+version = 1.0 SNAPSHOT
+
+[package]
+check_for_updates = 0
+
+[install]
+is_configured = 0
+
+[ui]
+is_visible = 1
+label = My Little App
+

--- a/vagrant_repo/apps/my_app/default/data/ui/nav/default.xml
+++ b/vagrant_repo/apps/my_app/default/data/ui/nav/default.xml
@@ -1,0 +1,3 @@
+<nav search_view="search" color="#72231F">
+  <view name="lorem_ipsum" default="true" />
+</nav>

--- a/vagrant_repo/apps/my_app/default/data/ui/views/lorem_ipsum.xml
+++ b/vagrant_repo/apps/my_app/default/data/ui/views/lorem_ipsum.xml
@@ -1,0 +1,10 @@
+<dashboard>
+  <label>Lorem Ipsum</label>
+  <description>Hurray!</description>
+  <row>
+    <html>
+      <img src="http://33.media.tumblr.com/tumblr_lzkpw7DAl21qhy6c9o4_250.gif"/>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam blandit fringilla ex, nec vehicula nunc ornare efficitur. Maecenas auctor lacus justo, imperdiet dapibus eros pharetra sed. Proin eget erat varius, elementum lorem non, aliquet ante. Fusce dapibus ligula sit amet velit blandit, facilisis fringilla erat ornare. Sed id neque in augue maximus mattis a quis orci. Quisque consequat nibh nulla, a sagittis eros imperdiet sed. Sed at risus a nisi placerat egestas. Vivamus aliquet venenatis lacus, molestie tempor odio gravida posuere. Donec eros lectus, gravida id placerat eu, rhoncus eu metus. Donec eget nisl lobortis, fringilla massa non, accumsan purus. Integer eget orci consequat, efficitur sapien eget, ornare odio. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean pretium fringilla mauris vitae vulputate. Duis aliquam tellus vel ex imperdiet gravida. Donec tempus consequat volutpat.</p>
+    </html>
+  </row>
+</dashboard>

--- a/vagrant_repo/apps/my_app/metadata/default.meta
+++ b/vagrant_repo/apps/my_app/metadata/default.meta
@@ -1,0 +1,2 @@
+[]
+access = read : [ * ]

--- a/vagrant_repo/data_bags/cerner_splunk/apps-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/apps-vagrant.json
@@ -1,6 +1,12 @@
 {
   "id": "apps-vagrant",
   "apps": {
+    "my_app": {
+      "download": {
+        "url" : "http://33.33.33.33:5000/my_app.tgz",
+        "version" : "1.0"
+      }
+    },
     "awesome_splunk_app": {
       "files": {
         "app.conf": {


### PR DESCRIPTION
Implementation of #37. This was quite the adventure. But this gives us the ability to install apps from .tar.gz files (and .spl, but .spl is just a renamed .tar.gz). We'll need a new enhancement / issue if we want to install apps from .zip files as well. (In the past few days I've seen a number zip files with all kinds of formats.)

Please review and be harsh! Question everything!