### PR TITLE
Fixes #47 - _configure_apps runs when there is no configured cluster databag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 3.0', group: :deployment
+gem 'berkshelf', '~> 3.0'
 gem 'rubocop', '~> 0.18'
 gem 'foodcritic', '~> 4.0'
 gem 'rspec',  '~> 3.1'
+gem 'chefspec', '~> 4.2'
 
 # https://github.com/opscode/chef/issues/2547
 if Bundler.current_ruby.on_19?

--- a/recipes/_configure_apps.rb
+++ b/recipes/_configure_apps.rb
@@ -9,8 +9,10 @@ attributes = node['splunk']['apps']
 
 attributes_bag = CernerSplunk::DataBag.load(attributes['bag']) || {}
 
+# Handle the case where we might not have a cluster
+cluster_data = CernerSplunk.my_cluster_data(node) || {}
 # warn if the cluster's apps bag is not available on forwarders, but fail for any servers.
-cluster_bag = CernerSplunk::DataBag.load(CernerSplunk.my_cluster_data(node)['apps'], pick_context: CernerSplunk.keys(node), handle_load_failure: node['splunk']['node_type'] == :forwarder) || {}
+cluster_bag = CernerSplunk::DataBag.load(cluster_data['apps'], pick_context: CernerSplunk.keys(node), handle_load_failure: node['splunk']['node_type'] == :forwarder) || {}
 
 bag_bag = CernerSplunk::DataBag.load(cluster_bag['bag']) || {}
 

--- a/spec/unit/libraries/splunk_app_spec.rb
+++ b/spec/unit/libraries/splunk_app_spec.rb
@@ -1,3 +1,5 @@
+# coding: UTF-8
+
 require_relative '../spec_helper'
 require 'splunk_app'
 

--- a/spec/unit/recipes/_configure_apps_spec.rb
+++ b/spec/unit/recipes/_configure_apps_spec.rb
@@ -1,0 +1,12 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_configure_apps' do
+  subject do
+    runner = ChefSpec::SoloRunner.new
+    runner.converge(described_recipe)
+  end
+
+  it { is_expected.to_not be_nil }
+end

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -2,7 +2,10 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', 'libraries'))
 require 'rspec'
+require 'chefspec'
+require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
 end


### PR DESCRIPTION
Fix for #47. Simply add a little indirection and voila. Also a very simple chefspec test as a first step. Would like to start doing more of these.