### PR TITLE
Fixes #64 - Tweaks to packaged app installation

### DIFF
--- a/libraries/splunk_template.rb
+++ b/libraries/splunk_template.rb
@@ -21,7 +21,6 @@ class Chef
 
       provides :splunk_template, (use_provider_resolver ? {} : { on_platforms: :all })
 
-      # rubocop:disable MethodLength
       def initialize(name, run_context = nil)
         super
         @resource_name = :splunk_template
@@ -48,7 +47,6 @@ class Chef
           @path = "etc/#{Regexp.last_match[1]}s/#{Regexp.last_match[2]}/local/#{Regexp.last_match[3]}"
         end
       end
-      # rubocop:enable MethodLength
 
       delayable_attribute :stanzas, default: {}, kind_of: Hash
 

--- a/recipes/cluster_master.rb
+++ b/recipes/cluster_master.rb
@@ -27,9 +27,13 @@ bag_bag = CernerSplunk::DataBag.load(cluster_bag['bag']) || {}
 apps = CernerSplunk::SplunkApp.merge_hashes(bag_bag, cluster_bag)
 
 apps.each do |app_name, app_data|
+  download_data = app_data['download'] || {}
+
   splunk_app app_name do
     apps_dir "#{node['splunk']['home']}/etc/master-apps"
     action app_data['remove'] ? :remove : :create
+    url download_data['url']
+    version download_data['version']
     local app_data['local']
     files app_data['files']
     permissions app_data['permissions']


### PR DESCRIPTION
To get this in, here are the fixes for windows installation of apps (i.e. do not chown on windows), and the fix for cluster apps (i.e. actually respect the download attributes)

There's also a rubocop update as well.