### PR TITLE
Fixes #68 - moving directory creation to after package install

### DIFF
--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -39,11 +39,6 @@ end
 manifest_missing = proc { ::Dir.glob("#{node['splunk']['home']}/#{node['splunk']['package']['name']}-*").empty? }
 
 # Actions
-directory node['splunk']['external_config_directory'] do
-  owner node['splunk']['user']
-  group node['splunk']['group']
-  mode '0700'
-end
 
 service 'splunk' do
   service_name service
@@ -70,6 +65,12 @@ package node['splunk']['package']['base_name'] do
   else
     notifies :run, 'execute[splunk-first-run]', :immediately
   end
+end
+
+directory node['splunk']['external_config_directory'] do
+  owner node['splunk']['user']
+  group node['splunk']['group']
+  mode '0700'
 end
 
 file 'splunk_package' do


### PR DESCRIPTION
Fixes #68 by creating the directory after the package (and subsequently the user) are installed.