### PR TITLE
Fixes #72 - Add Sensitive flag to License resource

### DIFF
--- a/recipes/license_server.rb
+++ b/recipes/license_server.rb
@@ -48,6 +48,7 @@ license_groups.each do |type, keys|
       owner node['splunk']['user']
       group node['splunk']['group']
       mode '0600'
+      sensitive true
       notifies :restart, 'service[splunk]'
     end
   end


### PR DESCRIPTION
Fixes #72 Apparently we missed adding the sensitive flag to the license resource. This will ensure that as new licenses are added we don't log out the contents.