### PR TITLE
Rubocop and Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ branches:
   except:
     - master
 language: ruby
-bundler_args: --without deployment
+cache: bundler
+sudo: false
 rvm:
 - 1.9.3
-- 2.1.4
+- 2.1.6
 script:
 - bundle exec rubocop
 - bundle exec foodcritic -f any .

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 3.0'
-gem 'rubocop', '~> 0.18'
+gem 'berkshelf', '~> 3.3'
+gem 'rubocop', '~> 0.33'
 gem 'foodcritic', '~> 4.0'
-gem 'rspec',  '~> 3.1'
-gem 'chefspec', '~> 4.2'
+gem 'rspec', '~> 3.3'
+gem 'chefspec', '~> 4.3'
 
 # https://github.com/opscode/chef/issues/2547
 if Bundler.current_ruby.on_19?
-  gem 'chef', '~> 11.0'
+  gem 'chef', '~> 11.18'
 else
-  gem 'chef', '~> 12.0'
+  gem 'chef', '~> 12.4'
 end

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -22,13 +22,13 @@ node.default['splunk']['package']['url'] =
 
 if platform_family?('windows')
   if node['kernel']['machine'] == 'x86_64'
-    node.default['splunk']['home'] = "#{ENV['PROGRAMW6432'].gsub('\\', '/')}/#{nsp['base_name']}"
+    node.default['splunk']['home'] = "#{ENV['PROGRAMW6432'].tr('\\', '/')}/#{nsp['base_name']}"
   else
-    node.default['splunk']['home'] = "#{ENV['PROGRAMFILES'].gsub('\\', '/')}/#{nsp['base_name']}"
+    node.default['splunk']['home'] = "#{ENV['PROGRAMFILES'].tr('\\', '/')}/#{nsp['base_name']}"
   end
-  # The regex is intended to switch the direction of slashes to be windows friendly,
+  # The translate is intended to switch the direction of slashes to be windows friendly,
   # the second replacement surrounds any file names with spaces in quotes
-  node.default['splunk']['cmd'] = "#{node['splunk']['home']}/bin/splunk".gsub('/', '\\').gsub(/\w+\s\w+/) { |directory| %("#{directory}") }
+  node.default['splunk']['cmd'] = "#{node['splunk']['home']}/bin/splunk".tr('/', '\\').gsub(/\w+\s\w+/) { |directory| %("#{directory}") }
   service = 'SplunkForwarder'
 else
   node.default['splunk']['home'] = "/opt/#{nsp['base_name']}"
@@ -61,7 +61,7 @@ package node['splunk']['package']['base_name'] do
   only_if(&manifest_missing)
   if platform_family?('windows')
     # installing as the system user by default as Splunk has difficulties with being a limited user
-    options %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="#{node['splunk']['home'].gsub('/', '\\')}")
+    options %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="#{node['splunk']['home'].tr('/', '\\')}")
   else
     notifies :run, 'execute[splunk-first-run]', :immediately
   end


### PR DESCRIPTION
* Fixing the Rubocop failures from #76
* Bumping minor versions in Gemfile to match the latest of each
* Updating to the [new Travis CI architecture](http://docs.travis-ci.com/user/migrating-from-legacy/)
* Bumping the ruby version to match the version shipped with omnibus chef 12.4.1

Proposed incrementing fix version for the cookbook with the merge of these changes.