### PR TITLE
Fixes #80 Ensure .ui_login file is always created

### DIFF
--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -91,8 +91,8 @@ end
 
 # This gets rid of the change password prompt on first login
 file "#{node['splunk']['home']}/etc/.ui_login" do
-  action :nothing
-  subscribes :touch, "package[#{node['splunk']['package']['name']}]", :immediately
+  action :touch
+  not_if { ::File.exist? "#{node['splunk']['home']}/etc/.ui_login" }
 end
 
 # System file changes should be done after first run, but before we start the server


### PR DESCRIPTION
Fixes #80. Instead of subscribing to a change, we're just going to ensure this file exists by touching it, but not if it already exists.

We probably should adopt this pattern with other resources too eventually.

Proposed: fix version increment as this is a bug.