### PR TITLE
Fixes #18 - Use a marker file for restart notifications

### DIFF
--- a/libraries/recipe.rb
+++ b/libraries/recipe.rb
@@ -20,6 +20,10 @@ module CernerSplunk
     node.default['splunk']['node_type'] = symbol.to_sym
   end
 
+  def self.restart_marker_file
+    "#{Chef::Config[:file_cache_path]}/.restart_splunk"
+  end
+
   # Returns the key identifing the current cluster
   def self.my_cluster_key(node)
     node['splunk']['config']['clusters'].first

--- a/providers/forwarder_monitors.rb
+++ b/providers/forwarder_monitors.rb
@@ -8,19 +8,29 @@
 action :install do # ~FC017
   input_stanzas = CernerSplunk::LWRP.convert_monitors(node, new_resource.monitors, new_resource.index)
 
+  file new_resource.app do
+    action :nothing
+    path CernerSplunk.restart_marker_file
+  end
+
   splunk_app new_resource.app do
     apps_dir "#{node['splunk']['home']}/etc/apps"
     action :create
     local true
     files 'inputs.conf' => input_stanzas
-    notifies :restart, 'service[splunk]'
+    notifies :touch, "file[#{new_resource.app}]", :immediately
   end
 end
 
 action :delete do  # ~FC017
+  file new_resource.app do
+    action :nothing
+    path CernerSplunk.restart_marker_file
+  end
+
   splunk_app new_resource.app do
     apps_dir "#{node['splunk']['home']}/etc/apps"
     action :remove
-    notifies :restart, 'service[splunk]'
+    notifies :touch, "file[#{new_resource.app}]", :immediately
   end
 end

--- a/recipes/_configure_alerts.rb
+++ b/recipes/_configure_alerts.rb
@@ -37,5 +37,5 @@ end
 
 splunk_template 'system/alert_actions.conf' do
   stanzas alert_stanzas
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end

--- a/recipes/_configure_apps.rb
+++ b/recipes/_configure_apps.rb
@@ -29,6 +29,6 @@ apps.each do |app_name, app_data|
     local app_data['local']
     files app_data['files']
     permissions app_data['permissions']
-    notifies :restart, 'service[splunk]'
+    notifies :touch, 'file[splunk-marker]', :immediately
   end
 end

--- a/recipes/_configure_authentication.rb
+++ b/recipes/_configure_authentication.rb
@@ -140,5 +140,5 @@ end
 splunk_template 'system/authentication.conf' do
   sensitive auth_stanzas.any? { |_, v| v.key? 'bindDNpassword' }
   stanzas auth_stanzas
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end

--- a/recipes/_configure_indexes.rb
+++ b/recipes/_configure_indexes.rb
@@ -55,6 +55,6 @@ path = is_master ? 'master-apps/_cluster/indexes.conf' : 'system/indexes.conf'
 
 splunk_template path do
   stanzas index_stanzas
-  notifies :restart, 'service[splunk]' unless is_master
+  notifies :touch, 'file[splunk-marker]', :immediately unless is_master
   notifies :run, 'execute[apply-cluster-bundle]' if is_master
 end

--- a/recipes/_configure_inputs.rb
+++ b/recipes/_configure_inputs.rb
@@ -27,5 +27,5 @@ end
 
 splunk_template 'system/inputs.conf' do
   stanzas input_stanzas
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end

--- a/recipes/_configure_outputs.rb
+++ b/recipes/_configure_outputs.rb
@@ -39,5 +39,5 @@ end
 splunk_template 'system/outputs.conf' do
   stanzas output_stanzas
   not_if { output_stanzas.empty? }
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end

--- a/recipes/_configure_roles.rb
+++ b/recipes/_configure_roles.rb
@@ -62,7 +62,7 @@ authorize_action = authorize.empty? ? :delete : :create
 splunk_template 'system/authorize.conf' do
   stanzas authorize
   action authorize_action
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end
 
 directory "#{node['splunk']['home']}/etc/apps/user-prefs/local" do
@@ -76,5 +76,5 @@ user_prefs_action = user_prefs.empty? ? :delete : :create
 splunk_template 'apps/user-prefs/user-prefs.conf' do
   stanzas user_prefs
   action user_prefs_action
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end

--- a/recipes/_configure_ui.rb
+++ b/recipes/_configure_ui.rb
@@ -7,5 +7,5 @@
 
 splunk_template 'system/ui-prefs.conf' do
   stanzas node['splunk']['config']['ui_prefs']
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -5,15 +5,16 @@
 #
 # Ensures the splunk instance is running, and performs post-start tasks.
 
-if platform_family?('windows')
-  ruby_block 'start splunk' do
-    block { true }
-    notifies :start, 'service[splunk]', :immediately
-  end
-else
-  execute "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}" do
-    notifies :start, 'service[splunk]', :immediately
-  end
+# We want to always ensure that the boot-start script is in place on non-windows platforms
+execute "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}" do
+  not_if { platform_family?('windows') }
+end
+
+# We then start splunk. In the future, the other resource should be here instead of this clumsy notification
+# but we'd need to refactor the determination of the service name away from the _install recipe.
+ruby_block 'start-splunk' do
+  block { true }
+  notifies :start, 'service[splunk-start]', :immediately
 end
 
 include_recipe 'cerner_splunk::_generate_password'

--- a/recipes/_user_management.rb
+++ b/recipes/_user_management.rb
@@ -29,7 +29,7 @@ groups_to_add.uniq.each do |grp|
     group_name grp
     members [node['splunk']['user']]
     action :manage
-    notifies :restart, 'service[splunk]'
+    notifies :touch, 'file[splunk-marker]', :immediately
   end
 end
 
@@ -42,7 +42,7 @@ if Chef::Resource::Group.instance_methods.include?(:excluded_members)
       group_name grp
       excluded_members [node['splunk']['user']]
       action :manage
-      notifies :restart, 'service[splunk]'
+      notifies :touch, 'file[splunk-marker]', :immediately
     end
   end
 else

--- a/recipes/license_server.rb
+++ b/recipes/license_server.rb
@@ -49,7 +49,7 @@ license_groups.each do |type, keys|
       group node['splunk']['group']
       mode '0600'
       sensitive true
-      notifies :restart, 'service[splunk]'
+      notifies :touch, 'file[splunk-marker]', :immediately
     end
   end
 end
@@ -67,7 +67,7 @@ b = ruby_block 'license cleanup' do
       @changed = to_delete.any?
     end
   end
-  notifies :restart, 'service[splunk]'
+  notifies :touch, 'file[splunk-marker]', :immediately
 end
 
 # Hack to not always notify with a ruby_block

--- a/vagrant_repo/cookbooks/cerner_splunk_test/providers/lwrp.rb
+++ b/vagrant_repo/cookbooks/cerner_splunk_test/providers/lwrp.rb
@@ -1,0 +1,9 @@
+use_inline_resources
+
+action :go do
+  cerner_splunk_forwarder_monitors new_resource.name do
+    app new_resource.app
+    index new_resource.index
+    monitors new_resource.monitors
+  end
+end

--- a/vagrant_repo/cookbooks/cerner_splunk_test/recipes/default.rb
+++ b/vagrant_repo/cookbooks/cerner_splunk_test/recipes/default.rb
@@ -28,7 +28,7 @@ end
   end
 end
 
-cerner_splunk_forwarder_monitors 'foo' do
+cerner_splunk_test_lwrp 'foo' do
   index 'pop_health'
   monitors [{
     path: '/testlogs/one/*.log',
@@ -40,7 +40,7 @@ cerner_splunk_forwarder_monitors 'foo' do
   }]
 end
 
-cerner_splunk_forwarder_monitors 'baz' do
+cerner_splunk_test_lwrp 'baz' do
   monitors [{
     path: '/testlogs/three/access2.log',
     sourcetype: 'access_combined'

--- a/vagrant_repo/cookbooks/cerner_splunk_test/resources/lwrp.rb
+++ b/vagrant_repo/cookbooks/cerner_splunk_test/resources/lwrp.rb
@@ -1,0 +1,5 @@
+default_action :go
+
+attribute :app,      kind_of: String, name_attribute: true, regex: [/^[A-Za-z0-9_-]/]
+attribute :index,    kind_of: String, required: false
+attribute :monitors, kind_of: Array, default: []


### PR DESCRIPTION
Fixes #18

Essentially we are implementing the design developed with https://github.com/cerner/cerner_splunk/pull/22#issuecomment-124629692 

But we create a marker file, and setup a delayed restart at the beginning. Every time we make a change, we touch the marker file. If we successfully start or restart, we delete the marker file.

Proposing a Minor version increment as while it fixes the expected state, it feels broader than just a simple fix.