### PR TITLE
Update splunk artifacts to 6.2.5 in vagrant doc

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -11,16 +11,15 @@ Running with Vagrant
 * You can speed up repeated provisioning attempts by mirroring the Splunk package downloads locally:
   1. Download the needed splunk packages locally, in a directory structure mirroring that of download.splunk.com
     * You can find the suffixes of files at the [Splunk download page](http://splunk.com/download)
-    * Copy a download link, it will look like `http://www.splunk.com/page/download_track?file=6.0.1/splunk/linux/splunk-6.0.1-189883-linux-2.6-x86_64.rpm&platform=...`
+    * Copy a download link, it will look like `http://www.splunk.com/page/download_track?file=6.2.5/splunk/linux/splunk-6.2.5-272645-linux-2.6-x86_64.rpm&platform=...`
     * The `file` query parameter will be the suffix you add onto `http://download.splunk.com/releases/`
-      * In this example the full url is: `http://download.splunk.com/releases/6.0.1/splunk/linux/splunk-6.0.1-189883-linux-2.6-x86_64.rpm`
-      * You will download the file locally to `<Mirror root>/releases/6.0.1/splunk/linux/splunk-6.0.1-189883-linux-2.6-x86_64.rpm
+      * In this example the full url is: `http://download.splunk.com/releases/6.2.5/splunk/linux/splunk-6.2.5-272645-linux-2.6-x86_64.rpm`
+      * You will download the file locally to `<Mirror root>/releases/6.2.5/splunk/linux/splunk-6.2.5-272645-linux-2.6-x86_64.rpm
   * Host the root of your mirrored structure on port 8080 using a lightweight HTTP server such as the node package [http-server](https://npmjs.org/package/http-server)
   * Un-comment the `splunk-mirrors` role in the Vagrant file. (Do not check in this modification of your Vagrantfile)
-  * Required files and sizes (assuming current cookbook versions and running the aeon-forwarder test as well)
-    * `splunk-6.0.1-189883-linux-2.6-x86_64.rpm` and `splunk-6.0.1-189883-linux-2.6-amd64.deb` ~ 75MB each
-    * `splunkforwarder-6.0.1-189883-linux-2.6-x86_64.rpm` and `splunkforwarder-6.0.1-189883-linux-2.6-amd64.deb` ~ 11MB each
-    * `splunkforwarder-4.3-115073-Linux-x86_64.tgz` ~ 18MB
+  * Required files and sizes (assuming current cookbook versions)
+    * `splunk-6.2.5-272645-linux-2.6-x86_64.rpm` and `splunk-6.2.5-272645-linux-2.6-amd64.deb` ~ 87MB each
+    * `splunkforwarder-6.2.5-272645-linux-2.6-x86_64.rpm` and `splunkforwarder-6.2.5-272645-linux-2.6-amd64.deb` ~ 13MB each
 * `vagrant-omnibus` installer currently requires internet access to function.
 
 Docs Navigation


### PR DESCRIPTION
The vagrant doc file had out of date artifact versions, updated to match the current defaults in `attributes/_install.rb`.