### PR TITLE
Fixes #96. Add ulimit command to init.d script to ensure ulimits are applied

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,11 +6,11 @@ DEPENDENCIES
 GRAPH
   build-essential (2.2.4)
   cerner_splunk (1.13.0)
-    chef-vault (~> 1.2)
+    chef-vault (= 1.3.0)
     ulimit (~> 0.3.2)
     xml (~> 1.2)
   chef-sugar (3.1.1)
-  chef-vault (1.3.2)
+  chef-vault (1.3.0)
   ulimit (0.3.3)
   xml (1.3.1)
     build-essential (>= 0.0.0)

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rubocop', '~> 0.33'
 gem 'foodcritic', '~> 4.0'
 gem 'rspec', '~> 3.3'
 gem 'chefspec', '~> 4.3'
+gem 'chef-vault'
 
 # https://github.com/opscode/chef/issues/2547
 if Bundler.current_ruby.on_19?

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,9 @@ description      'Installs/Configures Splunk Servers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.13.0'
 
-depends          'chef-vault', '~> 1.2'
+# Locking chef-vault to 1.3.0 due to the introduction of Ruby 2.x specific syntax in newer version. As long as Support
+# for Chef 11 is needed. See https://github.com/chef-cookbooks/chef-vault/issues/41
+depends          'chef-vault', '= 1.3.0'
 depends          'ulimit', '~> 0.3.2'
 depends          'xml', '~> 1.2'
 

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -38,13 +38,9 @@ end
 
 manifest_missing = proc { ::Dir.glob("#{node['splunk']['home']}/#{node['splunk']['package']['name']}-*").empty? }
 
-# Actions
-file 'splunk-marker' do
-  action :nothing
-  backup false
-  path CernerSplunk.restart_marker_file
-end
+include_recipe 'cerner_splunk::_restart_marker'
 
+# Actions
 # This service definition is used only for ensuring splunk is started during the run
 service 'splunk-start' do
   service_name service

--- a/recipes/_restart_marker.rb
+++ b/recipes/_restart_marker.rb
@@ -1,0 +1,13 @@
+# coding: UTF-8
+#
+# Cookbook Name:: cerner_splunk
+# Recipe:: _restart_marker
+#
+# Creates the restart file marker. This is used to ensure that the service is only restarted once and that it
+# only restarts when needed
+
+file 'splunk-marker' do
+  action :nothing
+  backup false
+  path CernerSplunk.restart_marker_file
+end

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -5,9 +5,28 @@
 #
 # Ensures the splunk instance is running, and performs post-start tasks.
 
+ulimit_command = "ulimit -n #{node['splunk']['limits']['open_files']}"
+init_file_path = '/etc/init.d/splunk'
+restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).grep(/#{ulimit_command}/).any?)
+
 # We want to always ensure that the boot-start script is in place on non-windows platforms
 execute "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}" do
   not_if { platform_family?('windows') }
+end
+
+ruby_block 'insert ulimit' do
+  block do
+    file = Chef::Util::FileEdit.new(init_file_path)
+    file.insert_line_after_match(/^RETVAL=\d$/, ulimit_command)
+    file.write_file
+  end
+  not_if { platform_family?('windows') }
+end
+
+ruby_block 'restart-splunk-for-ulimit' do
+  block { true }
+  notifies :touch, 'file[splunk-marker]', :immediately
+  only_if { !platform_family?('windows') && restart_flag }
 end
 
 # We then start splunk. In the future, the other resource should be here instead of this clumsy notification

--- a/spec/unit/recipes/_restart_marker_spec.rb
+++ b/spec/unit/recipes/_restart_marker_spec.rb
@@ -1,0 +1,18 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_restart_marker' do
+  subject do
+    runner = ChefSpec::SoloRunner.new
+    runner.converge(described_recipe)
+  end
+
+  before do
+    allow(CernerSplunk).to receive(:restart_marker_file).and_return('/foo/bar')
+  end
+
+  it 'does nothing with the splunk marker file' do
+    expect(subject.file('splunk-marker')).to do_nothing
+  end
+end

--- a/spec/unit/recipes/_start_spec.rb
+++ b/spec/unit/recipes/_start_spec.rb
@@ -1,0 +1,145 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_start' do
+  subject do
+    runner = ChefSpec::SoloRunner.new(platform: platform, version: platform_version) do |node|
+      node.set['splunk']['cmd'] = 'splunk'
+      node.set['splunk']['user'] = 'splunk'
+      node.set['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
+    end
+    # Have to include forwarder recipe so that _start recipe can send notifications to services
+    runner.converge('cerner_splunk::forwarder', described_recipe)
+  end
+
+  let(:cluster_config) do
+    {
+      cluster: {
+        receivers: ['33.33.33.20'],
+        license_uri: nil,
+        receiver_settings: {
+          splunktcp: {
+            port: '9997'
+          }
+        },
+        indexes: 'cerner_splunk/indexes'
+      }
+    }
+  end
+
+  let(:platform) { nil }
+  let(:platform_version) { nil }
+
+  let(:lines) { [] }
+  let(:exists) { nil }
+
+  let(:windows) { nil }
+
+  before do
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'cluster').and_return(cluster_config)
+    allow(Chef::Recipe).to receive(:platform_family?).with('windows').and_return(windows)
+
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with('/etc/init.d/splunk').and_return(exists)
+    allow(File).to receive(:readlines).and_call_original
+    allow(File).to receive(:readlines).with('/etc/init.d/splunk').and_return(lines)
+
+    # Stub alt separator for windows in Ruby 1.9.3
+    stub_const('::File::ALT_SEPARATOR', '|')
+  end
+
+  context 'when platform is windows' do
+    let(:platform) { 'windows' }
+    let(:platform_version) { '2012R2' }
+    let(:windows) { true }
+
+    before do
+      ENV['PROGRAMW6432'] = 'test'
+    end
+
+    it 'does not execute boot-start script' do
+      expect(subject).to_not run_execute('splunk enable boot-start -user splunk')
+    end
+
+    it 'does not insert ulimit into init.d script' do
+      expect(subject).to_not run_ruby_block('insert ulimit')
+    end
+
+    it 'does not run restart-splunk-for-ulimit ruby block' do
+      expect(subject).not_to run_ruby_block('restart-splunk-for-ulimit')
+    end
+  end
+
+  context 'when platform is not windows' do
+    let(:platform) { 'centos' }
+    let(:platform_version) { '6.6' }
+    let(:windows) { false }
+
+    it 'executes boot-start script' do
+      expect(subject).to run_execute('splunk enable boot-start -user splunk')
+    end
+
+    it 'inserts ulimit into init.d script' do
+      expect(subject).to run_ruby_block('insert ulimit')
+    end
+
+    context 'when init.d script does not exist' do
+      let(:exists) { false }
+
+      it 'notifies the touch restart-marker resource' do
+        expect(subject).to run_ruby_block('restart-splunk-for-ulimit')
+        expect(subject.ruby_block('restart-splunk-for-ulimit')).to notify('file[splunk-marker]').to(:touch).immediately
+      end
+    end
+
+    context 'when init.d script does exist' do
+      let(:exists) { true }
+
+      context 'when ulimit is not present in init.d script' do
+        let(:lines) { ['line 1', 'line 2'] }
+
+        it 'inserts ulimit into init.d script' do
+          expect(subject).to run_ruby_block('insert ulimit')
+        end
+
+        it 'notifies the touch restart-marker resource' do
+          expect(subject).to run_ruby_block('restart-splunk-for-ulimit')
+          expect(subject.ruby_block('restart-splunk-for-ulimit')).to notify('file[splunk-marker]').to(:touch).immediately
+        end
+      end
+
+      context 'when ulimit is present in init.d script' do
+        context 'when ulimit command is same as the one to be added' do
+          let(:lines) { ['line 1', 'ulimit -n 8192'] }
+
+          it 'inserts ulimit into init.d script' do
+            expect(subject).to run_ruby_block('insert ulimit')
+          end
+
+          it 'does not run restart-splunk-for-ulimit ruby block' do
+            expect(subject).not_to run_ruby_block('restart-splunk-for-ulimit')
+          end
+        end
+
+        context 'when ulimit command is different than the one to be added' do
+          let(:lines) { ['line 1', 'ulimit -n 1234'] }
+
+          it 'inserts ulimit into init.d script' do
+            expect(subject).to run_ruby_block('insert ulimit')
+          end
+
+          it 'notifies the touch restart-marker resource' do
+            expect(subject).to run_ruby_block('restart-splunk-for-ulimit')
+            expect(subject.ruby_block('restart-splunk-for-ulimit')).to notify('file[splunk-marker]').to(:touch).immediately
+          end
+        end
+      end
+    end
+  end
+
+  it 'notifies the start splunk resource' do
+    expect(subject).to run_ruby_block('start-splunk')
+    expect(subject.ruby_block('start-splunk')).to notify('service[splunk-start]').to(:start).immediately
+  end
+end


### PR DESCRIPTION
Updated _start recipe to edit the splunk init.d script with a ulimit command if needed.