### PR TITLE
Allow convenient specification of volumes for index storage locations

### DIFF
--- a/docs/databags.md
+++ b/docs/databags.md
@@ -37,7 +37,9 @@ Indexes Hash
 ------------
 An Indexes Hash is part of a plaintext data bag item that defines the set of indexes defined in a cluster. It is separate from the Cluster data bag primarily for size concerns.
 
-* `['config']` - These define the [indexes.conf] stanzas (in fairly raw form).
+* `['config']` - These define the [indexes.conf] stanzas (in fairly raw form). However there are a few special keys:
+    * `_volume` - The base volume for the coldPath, homePath and tstatsHomePath. Defaults to nil, so the index will be located in $SPLUNK_DB.
+    * `_directory_name` - The on-disk name of the directory to store the index. Defaults to the index name.
 * `['flags']` - These define boolean processing flags per index. All flags are default 'false' but can be set to true. Current flags include:
     * `noGeneratePaths` - Do not generate the homePath,coldPath,thawedPath to this index when not present in the config above
     * `noRepFactor` - Do not add 'repFactor = auto' to this index when not present in the config on a cluster master.
@@ -90,7 +92,7 @@ Apps Hash
 -----------
 An apps hash is a contextual (see above) Hash, part of a plaintext data bag item or specified directly as attributes that configures apps. A special key of 'master-apps' is looked for managing apps that should be installed and pushed by the cluster master, instead of locally.
 
-* `['bag']` - A string that points to an externalized Apps Hash in which all keys (except this one) are valid. 
+* `['bag']` - A string that points to an externalized Apps Hash in which all keys (except this one) are valid.
 * `[app]` - The name of an app to manage (disk name)
 * `[app]['remove']` - If true, remove this app instead of creating / managing  (default - false)
 * `[app]['local']` - If true, manage `[app]['files']` defined files and `[app]['permissions']` defined metadata in the "local" directory and "local.meta" instead of the "default" directory and "default.meta" (default - false, but forced true if download-url is specified)

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,14 @@
+# In order to work on chef 11.x the file must be here rather than under matchers/splunk_template.rb
+if defined?(ChefSpec)
+  ChefSpec.define_matcher :create_splunk_template
+
+  def create_splunk_template(resource)
+    # Names of resources in the resource collection work differently in Chef 11.x vs. 12.x.
+    provider_resolver_defined = defined?(Chef::ProviderResolver) == 'constant' && Chef::ProviderResolver.class == Class
+    if provider_resolver_defined
+      ChefSpec::Matchers::ResourceMatcher.new(:splunk_template, :create, resource)
+    else
+      ChefSpec::Matchers::ResourceMatcher.new(:template, :create, resource)
+    end
+  end
+end

--- a/recipes/_configure_indexes.rb
+++ b/recipes/_configure_indexes.rb
@@ -38,9 +38,13 @@ index_stanzas = config.inject({}) do |result, (stanza, index_config)|
 
   if stanza_type == :index
     unless index_flags['noGeneratePaths']
-      hash['coldPath'] = "$SPLUNK_DB/#{stanza}/colddb" unless hash['coldPath']
-      hash['homePath'] = "$SPLUNK_DB/#{stanza}/db" unless hash['homePath']
-      hash['thawedPath'] = "$SPLUNK_DB/#{stanza}/thaweddb" unless hash['thawedPath']
+      volume = hash.delete('_volume')
+      base_path = volume ? "volume:#{volume}" : '$SPLUNK_DB'
+      dir_name = hash.key?('_directory_name') ? hash.delete('_directory_name') : stanza
+      hash['coldPath'] = "#{base_path}/#{dir_name}/colddb" unless hash['coldPath']
+      hash['homePath'] = "#{base_path}/#{dir_name}/db" unless hash['homePath']
+      hash['thawedPath'] = "$SPLUNK_DB/#{dir_name}/thaweddb" unless hash['thawedPath']
+      hash['tstatsHomePath'] = "#{base_path}/#{dir_name}/datamodel_summary" if volume && !hash['tstatsHomePath']
     end
     if is_master && !index_flags['noRepFactor']
       hash['repFactor'] = 'auto' unless hash['repFactor']

--- a/spec/unit/recipes/_configure_indexes_spec.rb
+++ b/spec/unit/recipes/_configure_indexes_spec.rb
@@ -1,0 +1,68 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_configure_indexes' do
+  subject do
+    runner = ChefSpec::SoloRunner.new do |node|
+      node.set['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
+    end
+    # Have to include marker recipe so that we can send notifications to its resources
+    runner.converge('cerner_splunk::_restart_marker', described_recipe)
+  end
+
+  let(:cluster_config) do
+    {
+      'receivers' => ['33.33.33.20'],
+      'license_uri' => nil,
+      'receiver_settings' => {
+        'splunktcp' => {
+          'port' => '9997'
+        }
+      },
+      'indexes' => 'cerner_splunk/indexes'
+    }
+  end
+
+  let(:index_config) do
+    {
+      'config' => {
+        'volume:test' => {
+          'path' => '/test/path'
+        },
+        'index_a' => { '_directory_name' => 'foo' },
+        'index_b' => { '_volume' => 'test' }
+      }
+    }
+  end
+
+  before do
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'cluster').and_return(cluster_config)
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'indexes').and_return(index_config)
+  end
+
+  after do
+    CernerSplunk.reset
+  end
+
+  it 'writes the indexes.conf file' do
+    expected_attributes = {
+      stanzas: {
+        'volume:test' => index_config['config']['volume:test'],
+        'index_a' => {
+          'coldPath' => '$SPLUNK_DB/foo/colddb',
+          'homePath' => '$SPLUNK_DB/foo/db',
+          'thawedPath' => '$SPLUNK_DB/foo/thaweddb'
+        },
+        'index_b' => {
+          'coldPath' => 'volume:test/index_b/colddb',
+          'homePath' => 'volume:test/index_b/db',
+          'thawedPath' => '$SPLUNK_DB/index_b/thaweddb',
+          'tstatsHomePath' => 'volume:test/index_b/datamodel_summary'
+        }
+      }
+    }
+
+    expect(subject).to create_splunk_template('system/indexes.conf').with(expected_attributes)
+  end
+end

--- a/spec/unit/recipes/_start_spec.rb
+++ b/spec/unit/recipes/_start_spec.rb
@@ -15,16 +15,14 @@ describe 'cerner_splunk::_start' do
 
   let(:cluster_config) do
     {
-      cluster: {
-        receivers: ['33.33.33.20'],
-        license_uri: nil,
-        receiver_settings: {
-          splunktcp: {
-            port: '9997'
-          }
-        },
-        indexes: 'cerner_splunk/indexes'
-      }
+      'receivers' => ['33.33.33.20'],
+      'license_uri' => nil,
+      'receiver_settings' => {
+        'splunktcp' => {
+          'port' => '9997'
+        }
+      },
+      'indexes' => 'cerner_splunk/indexes'
     }
   end
 
@@ -38,6 +36,7 @@ describe 'cerner_splunk::_start' do
 
   before do
     allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'cluster').and_return(cluster_config)
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'indexes').and_return({})
     allow(Chef::Recipe).to receive(:platform_family?).with('windows').and_return(windows)
 
     allow(File).to receive(:exist?).and_call_original
@@ -47,6 +46,10 @@ describe 'cerner_splunk::_start' do
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '|')
+  end
+
+  after do
+    CernerSplunk.reset
   end
 
   context 'when platform is windows' do

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -9,3 +9,11 @@ RSpec.configure do |config|
   config.order = 'random'
   config.expect_with(:rspec) { |c| c.syntax = :expect }
 end
+
+module CernerSplunk
+  # Need a way to reset the cached module level variables between specs
+  def self.reset
+    @my_cluster_data = nil
+    @all_cluster_data = nil
+  end
+end

--- a/vagrant_repo/data_bags/cerner_splunk/indexes-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/indexes-vagrant.json
@@ -5,6 +5,12 @@
       "maxTotalDataSizeMB": 81920,
       "frozenTimePeriodInSecs": 15778800
     },
+    "volume:foo": {
+      "path": "/opt/splunk/data/foo_indexes"
+    },
+    "volume:bar": {
+      "path": "/opt/splunk/data/bar_indexes"
+    },
     "_audit": { "maxTotalDataSizeMB": 500000 },
     "_internal": {
       "maxTotalDataSizeMB": 500000,
@@ -16,8 +22,8 @@
       "maxDataSize": "auto",
       "maxMemMB": 1
     },
-    "opsinfra" : {},
-    "pop_health" : {},
+    "opsinfra" : { "_volume": "foo" },
+    "pop_health" : { "_volume": "bar" },
     "bobs_index_emporium": {},
     "summary": { "maxTotalDataSizeMB": 500000 }
   },


### PR DESCRIPTION
This allows a convenient way to specify the base volume for a given index.  Otherwise you would have to specify the coldPath and homePath for each index individually within the indexes data bag.  I originally considered putting the volume within the config/\<index_name\> location but then that hash would no longer match the raw indexes.conf stanza anymore.  So I opted to put it in the flags, although I know those were originally meant to be boolean only.  I'm open to suggestion on a better place to put the volume specification for an index in the data bag if you want to keep flags as only boolean attributes.