### PR TITLE
Make the source and issues url optional.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,8 @@ description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.14.0'
 
-source_url       'https://github.com/cerner/cerner_splunk'
-issues_url       'https://github.com/cerner/cerner_splunk/issues'
+source_url       'https://github.com/cerner/cerner_splunk' if defined?(:source_url)
+issues_url       'https://github.com/cerner/cerner_splunk/issues' if defined?(:issues_url)
 
 # Locking chef-vault to 1.3.0 due to the introduction of Ruby 2.x specific syntax in newer version. As long as Support
 # for Chef 11 is needed. See https://github.com/chef-cookbooks/chef-vault/issues/41


### PR DESCRIPTION
These weren't added until Chef 12, so we need to have them be optional for as long as we support Chef 11.
They were introduced with: chef/chef@fe6d60f7a9456a97457f37a20729e366a714f428

Proposing no version change on merge (as it's nothing to do with the cookbook itself, just the metadata of it.