### PR TITLE
Enable managing license pools

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -158,6 +158,8 @@ Vagrant.configure('2') do |config|
       cfg.vm.provision :chef_client do |chef|
         chef_defaults chef, symbol
         chef.add_recipe 'cerner_splunk::cluster_slave'
+        # Uncomment the line below to set predefined GUIDs on the cluster slaves (for playing with license pooling)
+        # chef.add_recipe 'cerner_splunk_test::configure_guids'
       end
       network cfg, symbol
     end

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -31,7 +31,8 @@ Configurable (with defaults)
 * `node['splunk']['package']['provider']` - Provider to use to install file (set based on ohai attributes)
 * `node['splunk']['config']['host']` - Hostname to configure the Splunk instance to report as. (EC2 Instance ID or Fully Qualified Domain Name)
 * `node['splunk']['config']['roles']` - Data bag item used to configure roles (`nil` - roles not managed by chef)
-* `node['splunk']['config']['licenses']` - Data bag item that the license server recipe uses as the source of truth for the license data (`cerner_splunk/licenses`)
+* `node['splunk']['config']['licenses']` - Data bag item that the license server recipe uses as the source of truth for the license data.
+* `node['splunk']['config']['license-pool']` - Data bag item used to configure license pools.
 * `node['splunk']['config']['ui_prefs']` - Hash of stanzas used to configure [ui-prefs.conf][] on the search head in a clustered configuration or a standalone instance.
 * `node['splunk']['config']['assumed_index']` - Name of the index to which data is forwarded to by default, when the index is not configured for the input.(`main`)
 * `node['splunk']['flags']['index_checks_fail']` - If `true` raises an exception failing the chef run, when monitors are configured to be sent to non-existent indexes. If `false` logs a warning, but does not fail the chef run for the same condition.(`true`)

--- a/docs/databags.md
+++ b/docs/databags.md
@@ -33,6 +33,14 @@ The License Hash is part of a data bag item encrypted with [Chef Vault](https://
 
 * `[A Decriptive File-Name]` - Corresponding License (XML) contents. (There can be many of these) Remember to change newlines to `\n` to conform to proper JSON format.
 
+License Pool Hash
+------------
+This hash is part of a plaintext data bag item that defines multiple license pools. Indexers can be assigned to a specific pool and license quota can be set for each pool by configuring this databag. Quota can be specified in units of B, KB(or KiB), MB(MiB), GB(GiB) or TB(TiB)(e.g. '400MB' or '400GiB'). If the unit is not specified then the quota is assumed to be in bytes.
+
+* `['auto_generated_pool_size']` - This is the pool size for the auto generated pool. Indexers that connect to the license server, when not assigned to a specific pool will land in this pool.
+* `['pools'][pool_name]['size']` -  Size of the pool
+* `['pools'][pool_name]['GUIDs']` - List of Indexer GUIDs that needs to be assigned to this pool.
+
 Indexes Hash
 ------------
 An Indexes Hash is part of a plaintext data bag item that defines the set of indexes defined in a cluster. It is separate from the Cluster data bag primarily for size concerns.

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -18,6 +18,11 @@ Running with Vagrant
     * `splunkforwarder-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm` and `splunkforwarder-6.3.3-f44afce176d0-linux-2.6-amd64.deb` ~ 16MB each
 * `vagrant-omnibus` installer currently requires internet access to function.
 
+**Note**: 
+If you want to set up the vagrant cluster to use the license pools defined in the [license pool hash](databags.md#license-pool-hash) databag, add the `configure_guids` recipe to the run_list on the cluster slave (to update the GUIDs on these slaves to predefined values) and update the `license_uri` attribute in the cluster-vagrant databag item to point to the cluster master (_https://33.33.33.30:8089_).
+After you spin up the cluster slaves you will have to restart the cluster master to bring the cluster to a stable state. While spinning up the cluster slaves, they are re-assigned with different GUIDS by the `configure_guids` recipe which requires a restart (this restart can take a while to complete). Cluster master is restarted so that it can identify the new GUIDS.
+
+
 Docs Navigation
 ===============
 * [Docs Readme](README.md)

--- a/libraries/unit_converter.rb
+++ b/libraries/unit_converter.rb
@@ -1,0 +1,33 @@
+# coding: UTF-8
+#
+# Cookbook Name:: cerner_splunk
+# File Name:: unit_converter.rb
+#
+# Module contains different functions used to manipulate the units of file sizes.
+#
+module CernerSplunk
+  SIZE_SCALE = %w(KB MB GB TB).freeze
+  REGEX = /(?i)^\s*+(\d++(?>\.\d+)?+)\s*+([kmgt](?>i?+b)?+|b?+)\s*+$/
+  POWER = { '' => 0, 'B' => 0, 'K' => 1, 'M' => 2, 'G' => 3, 'T' => 4 }.freeze
+  # Methods converts file sizes in KB, MB, GB and TB into Bytes.
+  def self.convert_to_bytes(string)
+    matchdata = string.match REGEX
+    fail "Unparsable size input #{string}" unless matchdata
+
+    size = matchdata[1].to_f
+    unit = matchdata[2].upcase[0, 1]
+
+    (size * 1024**POWER[unit]).floor
+  end
+
+  # Function returns the size in a human readable format.
+  def self.human_readable_size(filesize)
+    level = 0
+    human_size = filesize.fdiv(1024.0)
+    while human_size.fdiv(1024.0) > 0.5 && level + 1 < SIZE_SCALE.length
+      human_size = human_size.fdiv(1024.0)
+      level += 1
+    end
+    "#{human_size.round(2)} #{SIZE_SCALE[level]}"
+  end
+end

--- a/recipes/license_server.rb
+++ b/recipes/license_server.rb
@@ -23,15 +23,24 @@ unless bag
 end
 
 data_bag_item = bag.to_hash
+total_available_license_quota = 0
 
 license_groups = data_bag_item.inject('enterprise' => {}) do |hash, (key, value)|
   unless %w(id chef_type data_bag).include? key
     doc = Nokogiri::XML value
     type = doc.at_xpath('/license/payload/type/text()').to_s
+    quota = doc.at_xpath('/license/payload/quota/text()').to_s.to_i
+    expiration_time = doc.at_xpath('/license/payload/expiration_time/text()').to_s.to_i
+    total_available_license_quota += quota if type == 'enterprise' && expiration_time > Time.now.to_i
     hash[type] ||= {}
     hash[type][key] = value
   end
   hash
+end
+
+unless node.run_state['cerner_splunk']['total_allotted_pool_size'].nil?
+  total_allotted_pool_size = node.run_state['cerner_splunk']['total_allotted_pool_size']
+  fail "Sum of pool sizes is #{CernerSplunk.human_readable_size total_allotted_pool_size}. Exceeds total available pool size of #{CernerSplunk.human_readable_size total_available_license_quota}." if total_allotted_pool_size > total_available_license_quota
 end
 
 license_groups.each do |type, keys|

--- a/spec/unit/libraries/unit_converter_spec.rb
+++ b/spec/unit/libraries/unit_converter_spec.rb
@@ -1,0 +1,92 @@
+# coding: UTF-8
+require_relative '../spec_helper'
+require 'unit_converter'
+
+describe 'unit_converter' do
+  subject { CernerSplunk.convert_to_bytes(size) }
+
+  context 'when size specified in TB' do
+    let(:size) { '2TB' }
+    it { is_expected.to eq(2_199_023_255_552) }
+  end
+
+  context 'when size specified in MB' do
+    let(:size) { '2MB' }
+    it { is_expected.to eq(2_097_152) }
+  end
+
+  context 'when size specified in KB' do
+    let(:size) { '2KB' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when size specified in B' do
+    let(:size) { '2048B' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when size has no unit specified' do
+    let(:size) { '2048' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when unit has one letter' do
+    let(:size) { '2K' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when unit has three letters' do
+    let(:size) { '2KiB' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when input has space between size and unit' do
+    let(:size) { '2 KB' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when input has more than one space' do
+    let(:size) { ' 2 KB ' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when size is in lower case' do
+    let(:size) { '2kb' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when size is in upper case' do
+    let(:size) { '2KIB' }
+    it { is_expected.to eq(2048) }
+  end
+
+  context 'when size is a decimal' do
+    let(:size) { '2.5KB' }
+    it { is_expected.to eq(2560) }
+  end
+
+  context 'when size is a decimal, less than 1 and greater then zero' do
+    let(:size) { '0.5KB' }
+    it { is_expected.to eq(512) }
+  end
+
+  context 'when size is a decimal and ones place is nil' do
+    let(:size) { '.5KB' }
+    it { expect { subject }.to raise_error('Unparsable size input .5KB') }
+  end
+
+  context 'when size has an invalid unit' do
+    let(:size) { '5mk' }
+    it { expect { subject }.to raise_error('Unparsable size input 5mk') }
+  end
+
+  context 'when size only has invalid unit and no numeric value' do
+    let(:size) { 'invalidunit' }
+    it { expect { subject }.to raise_error('Unparsable size input invalidunit') }
+  end
+
+  context 'when input size is empty' do
+    let(:size) { '' }
+    it { expect { subject }.to raise_error('Unparsable size input ') }
+  end
+end

--- a/vagrant_repo/cookbooks/cerner_splunk_test/recipes/configure_guids.rb
+++ b/vagrant_repo/cookbooks/cerner_splunk_test/recipes/configure_guids.rb
@@ -1,0 +1,28 @@
+# coding: UTF-8
+#
+# Cookbook Name:: cerner_splunk_test
+# Recipe:: configure_guids
+#
+# Configures the GUIDS for cluster slaves.
+
+guid_c1_slave1 = 'aae84706-a70d-4134-951d-93a6541011fa'
+guid_c1_slave2 = '9d8f6bb8-49b2-463e-afdd-aedf267526e4'
+guid_c1_slave3 = '3da644f5-6750-4d07-b158-0cf42c8a6153'
+
+path = "#{node['splunk']['home']}/etc/instance.cfg"
+
+guid =
+  case node['hostname']
+  when 'slave01'
+    guid_c1_slave1
+  when 'slave02'
+    guid_c1_slave2
+  when 'slave03'
+    guid_c1_slave3
+  end
+
+template path do
+  source 'instance.cfg.erb'
+  variables guid: guid
+  notifies :touch, 'file[splunk-marker]', :immediately
+end

--- a/vagrant_repo/cookbooks/cerner_splunk_test/templates/default/instance.cfg.erb
+++ b/vagrant_repo/cookbooks/cerner_splunk_test/templates/default/instance.cfg.erb
@@ -1,0 +1,2 @@
+[general]
+guid = <%= @guid %>

--- a/vagrant_repo/data_bags/cerner_splunk/license-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/license-vagrant.json
@@ -1,0 +1,14 @@
+{
+  "id": "license-vagrant",
+  "auto_generated_pool_size": "100KiB", 
+  "pools":{
+    "pool1": {
+      "size": "200KiB",
+      "GUIDs": ["aae84706-a70d-4134-951d-93a6541011fa", "9d8f6bb8-49b2-463e-afdd-aedf267526e4"]
+    },
+    "pool2": {
+      "size": "400KiB",
+      "GUIDs": ["3da644f5-6750-4d07-b158-0cf42c8a6153"]
+    }
+  }
+}

--- a/vagrant_repo/environments/splunk_license.json
+++ b/vagrant_repo/environments/splunk_license.json
@@ -5,6 +5,7 @@
     "splunk": {
       "config": {
         "licenses": "cerner_splunk/license_secrets:licenses",
+        "license-pool": "cerner_splunk/license-vagrant",
         "authentication": "cerner_splunk/authnz-vagrant:authn"
       }
     }


### PR DESCRIPTION
This enhancement allows better management of license pools. Earlier all the indexers went into the same pool(auto_generated_pool) which had the max quota. You will now be able to specify which indexer goes into which pools and set the license quota for each pool. 