### PR TITLE
Splunk 6.3.3 Upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ if Bundler.current_ruby.on_19?
   gem 'faraday', '= 0.9.1'
   gem 'ridley', '= 4.2.0'
   gem 'varia_model', '= 0.4.1'
+  gem 'unicode-display_width', '= 0.3.1'
 else
   gem 'chef', '~> 12.4'
   gem 'berkshelf', '~> 4.0'

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -10,8 +10,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '6.2.5'
-default['splunk']['package']['build'] = '272645'
+default['splunk']['package']['version'] = '6.3.3'
+default['splunk']['package']['build'] = 'f44afce176d0'
 
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`6.0.6`)
-* `node['splunk']['package']['build']` - Corresponding build number (`228831`)
+* `node['splunk']['package']['version']` - Major version to install (`6.3.3`)
+* `node['splunk']['package']['build']` - Corresponding build number (`f44afce176d0`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -10,16 +10,12 @@ Running with Vagrant
   * `REGEN_APPS=1 vagrant provision chef` - Will repackage all apps.
 * You can speed up repeated provisioning attempts by mirroring the Splunk package downloads locally:
   1. Download the needed splunk packages locally, in a directory structure mirroring that of download.splunk.com
-    * You can find the suffixes of files at the [Splunk download page](http://splunk.com/download)
-    * Copy a download link, it will look like `http://www.splunk.com/page/download_track?file=6.2.5/splunk/linux/splunk-6.2.5-272645-linux-2.6-x86_64.rpm&platform=...`
-    * The `file` query parameter will be the suffix you add onto `http://download.splunk.com/releases/`
-      * In this example the full url is: `http://download.splunk.com/releases/6.2.5/splunk/linux/splunk-6.2.5-272645-linux-2.6-x86_64.rpm`
-      * You will download the file locally to `<Mirror root>/releases/6.2.5/splunk/linux/splunk-6.2.5-272645-linux-2.6-x86_64.rpm
+    * You can find URLs for Splunk packages at the [Splunk download page](http://splunk.com/download)
   * Host the root of your mirrored structure on port 8080 using a lightweight HTTP server such as the node package [http-server](https://npmjs.org/package/http-server)
   * Un-comment the `splunk-mirrors` role in the Vagrant file. (Do not check in this modification of your Vagrantfile)
   * Required files and sizes (assuming current cookbook versions)
-    * `splunk-6.2.5-272645-linux-2.6-x86_64.rpm` and `splunk-6.2.5-272645-linux-2.6-amd64.deb` ~ 87MB each
-    * `splunkforwarder-6.2.5-272645-linux-2.6-x86_64.rpm` and `splunkforwarder-6.2.5-272645-linux-2.6-amd64.deb` ~ 13MB each
+    * `splunk-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm` and `splunk-6.3.3-f44afce176d0-linux-2.6-amd64.deb` ~ 137MB each
+    * `splunkforwarder-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm` and `splunkforwarder-6.3.3-f44afce176d0-linux-2.6-amd64.deb` ~ 16MB each
 * `vagrant-omnibus` installer currently requires internet access to function.
 
 Docs Navigation

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -1,0 +1,214 @@
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_install' do
+  subject do
+    runner = ChefSpec::SoloRunner.new(platform: platform, version: platform_version) do |node|
+      node.set['splunk']['cmd'] = 'splunk'
+      node.set['splunk']['user'] = 'splunk'
+      node.set['splunk']['package']['base_name'] = 'splunkforwarder'
+      node.set['splunk']['package']['download_group'] = 'universalforwarder'
+      node.set['splunk']['package']['file_suffix'] = '.txt'
+      node.set['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
+    end
+    runner.converge(described_recipe)
+  end
+
+  let(:cluster_config) do
+    {
+      'receivers' => ['33.33.33.20'],
+      'license_uri' => nil,
+      'receiver_settings' => {
+        'splunktcp' => {
+          'port' => '9997'
+        }
+      },
+      'indexes' => 'cerner_splunk/indexes'
+    }
+  end
+
+  let(:platform) { nil }
+  let(:platform_version) { nil }
+
+  let(:initd_exists) { nil }
+  let(:ui_login_exists) { nil }
+  let(:glob) { [] }
+
+  let(:windows) { nil }
+
+  let(:splunk_file) { 'splunkforwarder-6.3.3-f44afce176d0' }
+  let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
+
+  before do
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'cluster').and_return(cluster_config)
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'indexes').and_return({})
+    allow(Chef::Recipe).to receive(:platform_family?).with('windows').and_return(windows)
+
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with('/etc/init.d/splunk').and_return(initd_exists)
+    allow(File).to receive(:exist?).with('/opt/splunkforwarder/etc/.ui_login').and_return(ui_login_exists)
+
+    allow(Dir).to receive(:glob).and_call_original
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.3.3-f44afce176d0-*').and_return(glob)
+
+    # Stub alt separator for windows in Ruby 1.9.3
+    stub_const('::File::ALT_SEPARATOR', '/')
+  end
+
+  after do
+    CernerSplunk.reset
+  end
+
+  it 'includes default chef-vault recipe' do
+    expect(subject).to include_recipe('chef-vault::default')
+  end
+
+  it 'includes cerner_splunk::_cleanup_aeon recipe' do
+    expect(subject).to include_recipe('cerner_splunk::_cleanup_aeon')
+  end
+
+  it 'includes cerner_splunk::_restart_marker recipe' do
+    expect(subject).to include_recipe('cerner_splunk::_restart_marker')
+  end
+
+  it 'does nothing with the splunk-start service and notifies the deletion of the splunk file marker immediately' do
+    splunk_start_service = subject.service('splunk-start')
+    expect(splunk_start_service).to do_nothing
+    expect(splunk_start_service).to notify('file[splunk-marker]').to(:delete).immediately
+  end
+
+  it 'does nothing with the splunk service and notifies the deletion of the splunk file marker immediately' do
+    splunk_service = subject.service('splunk')
+    expect(splunk_service).to do_nothing
+    expect(splunk_service).to notify('file[splunk-marker]').to(:delete).immediately
+  end
+
+  it 'runs ruby block splunk-delayed-restart' do
+    expect(subject).to run_ruby_block('splunk-delayed-restart')
+    expect(subject.ruby_block('splunk-delayed-restart')).to notify('service[splunk]').to(:restart)
+  end
+
+  context 'when remote file has missing manifest' do
+    let(:glob) { [] }
+
+    it 'downloads the remote file' do
+      expect(subject).to create_remote_file(splunk_filepath)
+    end
+
+    it 'does not delete the downloaded splunk package' do
+      expect(subject).to_not delete_file(splunk_filepath)
+    end
+
+    context 'when platform is windows' do
+      let(:platform) { 'windows' }
+      let(:platform_version) { '2012R2' }
+      let(:windows) { true }
+
+      before do
+        ENV['PROGRAMW6432'] = 'test'
+      end
+
+      it 'installs downloaded splunk package' do
+        expected_attrs = {
+          source: splunk_filepath,
+          provider: Chef::Provider::Package::Windows,
+          options: %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="test\\splunkforwarder")
+        }
+        if Chef::VERSION.slice(0..1) == '11'
+          expect(subject).to install_windows_package('splunkforwarder').with(expected_attrs)
+        else
+          expect(subject).to install_package('splunkforwarder').with(expected_attrs)
+        end
+      end
+    end
+
+    context 'when platform is rhel' do
+      let(:platform) { 'centos' }
+      let(:platform_version) { '6.6' }
+
+      it 'installs downloaded splunk package and notifies splunk-first-run' do
+        expected_attrs = {
+          source: splunk_filepath,
+          provider: Chef::Provider::Package::Rpm
+        }
+        expect(subject).to install_package('splunkforwarder').with(expected_attrs)
+        expect(subject.package('splunkforwarder')).to notify('execute[splunk-first-run]').to(:run).immediately
+      end
+    end
+
+    context 'when platform is debian' do
+      let(:platform) { 'ubuntu' }
+      let(:platform_version) { '14.04' }
+
+      it 'installs downloaded splunk package and notifies splunk-first-run' do
+        expected_attrs = {
+          source: splunk_filepath,
+          provider: Chef::Provider::Package::Dpkg
+        }
+        expect(subject).to install_package('splunkforwarder').with(expected_attrs)
+        expect(subject.package('splunkforwarder')).to notify('execute[splunk-first-run]').to(:run).immediately
+      end
+    end
+  end
+
+  context 'when remote file has manifest' do
+    let(:glob) { [1] }
+
+    it 'does not download the remote file' do
+      expect(subject).to_not create_remote_file(splunk_filepath)
+    end
+
+    it 'does not install downloaded splunk package' do
+      expect(subject).to_not install_package('splunkforwarder')
+    end
+
+    it 'deletes the downloaded splunk package' do
+      expect(subject).to delete_file(splunk_filepath)
+    end
+  end
+
+  it 'creates external config directory' do
+    expected_attrs = {
+      owner: 'splunk',
+      group: 'splunk',
+      mode: '0700'
+    }
+    expect(subject).to create_directory('/etc/splunk').with(expected_attrs)
+  end
+
+  it 'creates introspection log directory' do
+    expected_attrs = {
+      owner: 'splunk',
+      group: 'splunk',
+      mode: '0700'
+    }
+    expect(subject).to create_directory('/opt/splunkforwarder/var/log/introspection').with(expected_attrs)
+  end
+
+  it 'includes cerner_splunk::_user_management recipe' do
+    expect(subject).to include_recipe('cerner_splunk::_user_management')
+  end
+
+  it 'does nothing with splunk-first-run execution' do
+    expect(subject.execute('splunk-first-run')).to do_nothing
+  end
+
+  context 'when .ui_login file exists' do
+    let(:ui_login_exists) { true }
+
+    it 'does not touch .ui_login file' do
+      expect(subject).to_not touch_file('/opt/splunkforwarder/etc/.ui_login')
+    end
+  end
+
+  context 'when .ui_login file does not exists' do
+    let(:ui_login_exists) { false }
+
+    it 'touches .ui_login file' do
+      expect(subject).to touch_file('/opt/splunkforwarder/etc/.ui_login')
+    end
+  end
+
+  it 'includes cerner_splunk::_configure recipe' do
+    expect(subject).to include_recipe('cerner_splunk::_configure')
+  end
+end

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -7,6 +7,7 @@ require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.file_cache_path = '/var/chef/cache'
   config.expect_with(:rspec) { |c| c.syntax = :expect }
 end
 


### PR DESCRIPTION
* Update Splunk version attributes to be specific to Splunk 6.3.3
* Added ChefSpec tests for _install.rb recipe

Tested upgrade path from previous version by provisioning vagrant before and after switching the version attributes.