### PR TITLE
Fix chef-dk install command in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,7 @@ Vagrant.configure('2') do |config|
   config.vm.define :chef do |cfg|
     config.omnibus.chef_version = nil
 
-    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://chef.sh | bash -s -- -P chefdk'
+    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk'
 
     if ENV['KNIFE_ONLY']
       cfg.vm.provision :shell, inline: 'cd /vagrant/vagrant_repo; mv nodes .nodes.bak', privileged: false


### PR DESCRIPTION
This PR is to fix #110 where the chef-dk install fails when attempting to run vagrant. I based the new install command on the [chef-dk's readme installation instructions](https://github.com/chef/chef-dk#linux-and-osx)