### PR TITLE
Splunk 6.3.4

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -10,8 +10,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '6.3.3'
-default['splunk']['package']['build'] = 'f44afce176d0'
+default['splunk']['package']['version'] = '6.3.4'
+default['splunk']['package']['build'] = 'cae2458f4aef'
 
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`6.3.3`)
-* `node['splunk']['package']['build']` - Corresponding build number (`f44afce176d0`)
+* `node['splunk']['package']['version']` - Major version to install (`6.3.4`)
+* `node['splunk']['package']['build']` - Corresponding build number (`cae2458f4aef`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -14,8 +14,8 @@ Running with Vagrant
   * Host the root of your mirrored structure on port 8080 using a lightweight HTTP server such as the node package [http-server](https://npmjs.org/package/http-server)
   * Un-comment the `splunk-mirrors` role in the Vagrant file. (Do not check in this modification of your Vagrantfile)
   * Required files and sizes (assuming current cookbook versions)
-    * `splunk-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm` and `splunk-6.3.3-f44afce176d0-linux-2.6-amd64.deb` ~ 137MB each
-    * `splunkforwarder-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm` and `splunkforwarder-6.3.3-f44afce176d0-linux-2.6-amd64.deb` ~ 16MB each
+    * `splunk-6.3.4-cae2458f4aef-linux-2.6-x86_64.rpm` and `splunk-6.3.4-cae2458f4aef-linux-2.6-amd64.deb` ~ 137MB each
+    * `splunkforwarder-6.3.4-cae2458f4aef-linux-2.6-x86_64.rpm` and `splunkforwarder-6.3.4-cae2458f4aef-linux-2.6-amd64.deb` ~ 16MB each
 * `vagrant-omnibus` installer currently requires internet access to function.
 
 **Note**:

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -35,7 +35,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-6.3.3-f44afce176d0' }
+  let(:splunk_file) { 'splunkforwarder-6.3.4-cae2458f4aef' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -48,7 +48,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/etc/.ui_login').and_return(ui_login_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.3.3-f44afce176d0-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.3.4-cae2458f4aef-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Update default Splunk version attributes to install Splunk 6.3.4.

Also tested upgrade path from previous version by provisioning vagrant before and after switching the version attributes.
