### PR TITLE
splunk_app resource to support lookup specification

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,6 +106,8 @@ Vagrant.configure('2') do |config|
     app_gen = <<-'SCRIPT'.gsub(/^\s+/, '')
       mkdir -p "$HOME/app_service"
       rm -rf "$HOME/app_service/*"
+      cd /vagrant/vagrant_repo/files
+      cp -R lookups "$HOME/app_service/"
       cd /vagrant/vagrant_repo/apps
       timestamp=`date -u +%Y%m%d%H%M%S`
       for D in *; do

--- a/docs/databags.md
+++ b/docs/databags.md
@@ -109,6 +109,7 @@ An apps hash is a contextual (see above) Hash, part of a plaintext data bag item
 * `[app]['download']['version']` - Expected [version number][app.conf] (if any) used to determine if a new app should be downloaded.
 * `[app]['files']` - Hash of files to manage under the "default" or "local" directory.
 * `[app]['files'][filename]` - Contents of a particular file to manage. It can take 3 values, a hash of stanzas -> key-value pairs (then written with the splunk template), a string (written as is), or nil / false (deleted). If the hash or string is empty, the file is also deleted.
+* `[app]['lookups']` - Hash of lookup files for the app. The key in the hash will be the name of file when it lands in the Splunk app and the value will be the url to lookup file. To delete an existing lookup file, set the value of the lookup file to `false` or `null` or to an empty string. The only supported file name extensions are .csv, .csv.gz and .kmz. Please see [splunk docs](http://docs.splunk.com/Documentation/Splunk/6.3.2/Knowledge/Addfieldsfromexternaldatasources) for more information about the supported file formats. `[app]['files']` hash can be used to specify any .conf setting that is required for the lookup.
 * `[app]['permissions']` - Hash of permissions to manage for the app.
 * `[app]['permissions'][object]` - Permissions to manage for a particular knowledge object or class of knowledge objects
 * `[app]['permissions'][object]['access']['read']` - array of roles or String '*' allowed to read the object

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,14 +1,13 @@
-# In order to work on chef 11.x the file must be here rather than under matchers/splunk_template.rb
 if defined?(ChefSpec)
-  ChefSpec.define_matcher :create_splunk_template
-
   def create_splunk_template(resource)
-    # Names of resources in the resource collection work differently in Chef 11.x vs. 12.x.
-    provider_resolver_defined = defined?(Chef::ProviderResolver) == 'constant' && Chef::ProviderResolver.class == Class
-    if provider_resolver_defined
-      ChefSpec::Matchers::ResourceMatcher.new(:splunk_template, :create, resource)
-    else
-      ChefSpec::Matchers::ResourceMatcher.new(:template, :create, resource)
-    end
+    ChefSpec::Matchers::ResourceMatcher.new(:splunk_template, :create, resource)
+  end
+
+  def create_splunk_app(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:splunk_app, :create, resource)
+  end
+
+  def remove_splunk_app(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:splunk_app, :remove, resource)
   end
 end

--- a/recipes/_configure_apps.rb
+++ b/recipes/_configure_apps.rb
@@ -28,6 +28,7 @@ apps.each do |app_name, app_data|
     version download_data['version']
     local app_data['local']
     files app_data['files']
+    lookups app_data['lookups']
     permissions app_data['permissions']
     notifies :touch, 'file[splunk-marker]', :immediately
   end

--- a/spec/unit/recipes/_configure_apps_spec.rb
+++ b/spec/unit/recipes/_configure_apps_spec.rb
@@ -4,9 +4,60 @@ require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_apps' do
   subject do
-    runner = ChefSpec::SoloRunner.new
-    runner.converge(described_recipe)
+    runner = ChefSpec::SoloRunner.new do |node|
+      node.set['splunk']['apps'] = apps
+    end
+    runner.converge('cerner_splunk::_restart_marker', described_recipe)
+  end
+
+  let(:apps) do
+    {
+      'test_app' => {
+        'files' => {
+          'app.conf' => {
+            'ui' => {
+              'is_visible' => '1',
+              'label' => 'Test App'
+            }
+          }
+        },
+        'lookups' => {
+          'index-owners.csv' => 'http://33.33.33.33:5000/lookups/index-owners.csv'
+        }
+      }
+    }
   end
 
   it { is_expected.to_not be_nil }
+
+  it 'installs the app with the expected attributes' do
+    expected_attributes = {
+      lookups: {
+        'index-owners.csv' => 'http://33.33.33.33:5000/lookups/index-owners.csv'
+      },
+      files: {
+        'app.conf' => {
+          'ui' => {
+            'is_visible' => '1',
+            'label' => 'Test App'
+          }
+        }
+      }
+    }
+    expect(subject).to create_splunk_app('test_app').with(expected_attributes)
+  end
+
+  context 'when remove is set to true' do
+    let(:apps) do
+      {
+        'test_app' => {
+          'remove' => true
+        }
+      }
+    end
+
+    it 'removes the app' do
+      expect(subject).to remove_splunk_app('test_app')
+    end
+  end
 end

--- a/vagrant_repo/data_bags/cerner_splunk/apps-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/apps-vagrant.json
@@ -27,6 +27,10 @@
         "data/ui/views/all_index.xml": "<dashboard><label>Awesome_Dashboard</label><description>Bacon for all</description><row><chart><searchString>index=* | timechart count</searchString><earliestTime>@d</earliestTime><latestTime>now</latestTime></chart></row></dashboard>",
         "data/ui/nav/default.xml": "<nav search_view=\"search\" color=\"#72231F\"><view name=\"search\" default='true' /><view name=\"data_models\" /><view name=\"reports\" /><view name=\"alerts\" /><view name=\"dashboards\" /></nav>"
       },
+      "lookups": {
+        "index-owners.csv": "http://33.33.33.33:5000/lookups/index-owners.csv",
+        "test.csv": "http://33.33.33.33:5000/lookups/test.txt"
+      },
       "permissions": {
         "": {
           "access": {

--- a/vagrant_repo/files/lookups/index-owners.csv
+++ b/vagrant_repo/files/lookups/index-owners.csv
@@ -1,0 +1,4 @@
+index,owners
+index1,owner1
+index2,owner2
+index3,owner3

--- a/vagrant_repo/files/lookups/test.txt
+++ b/vagrant_repo/files/lookups/test.txt
@@ -1,0 +1,3 @@
+column00,column01,column02
+column10,,column12
+column20,column21,


### PR DESCRIPTION
This PR is to enhance the splunk_app resource to support lookup specification. 

The use case is that we need to deploy a lookup file to the license server so that we can have a index-ownership lookup which can potentially help in notifying the index owners about any over indexing that might lead to license violation. This enhancement will help us source control the contents of the lookup file. 