### PR TITLE
Drop Chef 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 1.9.3
 - 2.1.6
 script:
 - bundle exec rubocop

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,3 @@
-if respond_to? :source
-  source 'https://supermarket.chef.io'
-else
-  site :opscode
-end
+source 'https://supermarket.chef.io'
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -5,16 +5,5 @@ gem 'foodcritic', '~> 4.0'
 gem 'rspec', '~> 3.3'
 gem 'chefspec', '~> 4.3'
 gem 'chef-vault'
-
-# https://github.com/opscode/chef/issues/2547
-if Bundler.current_ruby.on_19?
-  gem 'chef', '~> 11.18'
-  gem 'berkshelf', '~> 3.3'
-  gem 'faraday', '= 0.9.1'
-  gem 'ridley', '= 4.2.0'
-  gem 'varia_model', '= 0.4.1'
-  gem 'unicode-display_width', '= 0.3.1'
-else
-  gem 'chef', '~> 12.4'
-  gem 'berkshelf', '~> 4.0'
-end
+gem 'chef', '~> 12.4'
+gem 'berkshelf', '~> 4.0'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Based on the work done by [BBY Solutions](https://github.com/bestbuycom/splunk_c
 Requirements
 ------------
 * Red Hat Enterprise / CentOS 5.5+ / Windows Server 2008+ (forwarder only) or Ubuntu LTS 12.04+
-* Chef 11.6+
+* Chef 12+
 
 Getting your logs into Splunk
 -----------------------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,9 +9,7 @@ version          '1.17.0'
 source_url       'https://github.com/cerner/cerner_splunk' if defined?(:source_url)
 issues_url       'https://github.com/cerner/cerner_splunk/issues' if defined?(:issues_url)
 
-# Locking chef-vault to 1.3.0 due to the introduction of Ruby 2.x specific syntax in newer version. As long as Support
-# for Chef 11 is needed. See https://github.com/chef-cookbooks/chef-vault/issues/41
-depends          'chef-vault', '= 1.3.0'
+depends          'chef-vault', '~> 1.3'
 depends          'ulimit', '~> 0.3.2'
 depends          'xml', '~> 1.2'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache 2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.17.0'
+version          '2.0.0'
 
-source_url       'https://github.com/cerner/cerner_splunk' if defined?(:source_url)
-issues_url       'https://github.com/cerner/cerner_splunk/issues' if defined?(:issues_url)
+source_url       'https://github.com/cerner/cerner_splunk'
+issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
 depends          'chef-vault', '~> 1.3'
 depends          'ulimit', '~> 0.3.2'


### PR DESCRIPTION
Fixes #117 also includes the commit from #114 that fixes #112

We'll bump the version number to 2.0 as part of this, so any features merged after this point are not guaranteed to work necessarily on Chef 11