### PR TITLE
Support encrypting passwords when written to conf files

### DIFF
--- a/libraries/rc4.rb
+++ b/libraries/rc4.rb
@@ -1,0 +1,78 @@
+# coding: UTF-8
+#
+# Cookbook Name:: cerner_splunk
+# File Name:: rc4.rb
+
+# RC4 implementation in this module is taken from https://github.com/caiges/Ruby-RC4
+# (SHA: c4c56511bd4f98312d6cad28c6836dc6043d7453) project under the MIT license below.
+#
+# The MIT License
+
+# Copyright (C) 2010 Max Prokopiev, Alexandar Simic, Caige Nichols
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+module CernerSplunk
+  # Implementation of RC4 algorithm
+  class RC4
+    def initialize(str)
+      initialize_state(str)
+      @q1 = 0
+      @q2 = 0
+    end
+
+    def encrypt!(text)
+      index = 0
+      while index < text.length
+        @q1 = (@q1 + 1) % 256
+        @q2 = (@q2 + @state[@q1]) % 256
+        @state[@q1], @state[@q2] = @state[@q2], @state[@q1]
+        text.setbyte(index, text.getbyte(index) ^ @state[
+        (@state[@q1] + @state[@q2]) % 256])
+        index += 1
+      end
+      text
+    end
+
+    alias decrypt! encrypt!
+
+    def encrypt(text)
+      encrypt!(text.dup)
+    end
+
+    alias decrypt encrypt
+
+    private
+
+    # The initial state which is then modified by the key-scheduling algorithm
+    INITIAL_STATE = (0..255).to_a
+
+    # Performs the key-scheduling algorithm to initialize the state.
+    def initialize_state(key)
+      i = j = 0
+      @state = INITIAL_STATE.dup
+      key_length = key.length
+      while i < 256
+        j = (j + @state[i] + key.getbyte(i % key_length)) % 256
+        @state[i], @state[j] = @state[j], @state[i]
+        i += 1
+      end
+    end
+  end
+end

--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -1,0 +1,46 @@
+# coding: UTF-8
+#
+# Cookbook Name:: cerner_splunk
+# File Name:: splunk_password.rb
+
+require 'base64'
+
+# Module contains different functions to encrypt and decrypt splunk passwords
+module CernerSplunk
+  # Encrypts the password before writing into config files. As of now all the passwords
+  # needs to be XORed except for the sslKeyFilePassword. The boolean
+  # parameter xor controls the XOR logic.
+  def self.splunk_encrypt_password(plain_text, splunk_secret, xor = true)
+    rc4key = splunk_secret.strip[0..15]
+
+    password =
+      if xor
+        pwd = plain_text.unpack('c*')
+        xorkey = get_xor_key(pwd.size)
+        pwd.zip(xorkey).map { |c1, c2| c1 ^ c2 }.pack('c*')
+      end || plain_text
+
+    '$1$' + Base64.encode64(CernerSplunk::RC4.new(rc4key).encrypt("#{password}\0")).strip!
+  end
+
+  # Decrypts the splunk passwords. As of now the encrypted passwords needs to be XORed
+  # to retrieve the plain_text for every password except the sslKeyFilePassword.
+  # The boolean parameter xor controls the XOR logic.
+  def self.splunk_decrypt_password(encryp_password, splunk_secret, xor = true)
+    rc4key = splunk_secret.strip[0..15]
+    pwd = CernerSplunk::RC4.new(rc4key).decrypt(Base64.decode64(encryp_password.sub('$1$', ''))).chomp("\0")
+
+    return pwd unless xor
+
+    password = pwd.unpack('c*')
+    xorkey = get_xor_key(password.size)
+    password.zip(xorkey).map { |c1, c2| c1 ^ c2 }.pack('c*')
+  end
+
+  # Return the key used to XOR with the password
+  def self.get_xor_key(password_size)
+    xorkey = 'DEFAULTSA'.unpack('c*')
+    xorkey += xorkey while xorkey.size < password_size
+    xorkey
+  end
+end

--- a/libraries/splunk_template.rb
+++ b/libraries/splunk_template.rb
@@ -54,6 +54,12 @@ class Chef
         if args || val
           val
         else
+          # evaluating the procs if an attribute in the stanza has a value which is a proc
+          stanzas.each do |stanza, contents|
+            contents.each do |attribute, value|
+              stanzas[stanza][attribute] = value.call if value.is_a? Proc
+            end
+          end
           { stanzas: stanzas }
         end
       end

--- a/recipes/_configure_authentication.rb
+++ b/recipes/_configure_authentication.rb
@@ -108,7 +108,7 @@ when 'LDAP'
     if hash['bindDNpassword']
       password = CernerSplunk::DataBag.load hash['bindDNpassword'], default: default_coords, type: :vault
       fail 'Password must be a String' unless password.is_a?(String)
-      hash['bindDNpassword'] = password
+      hash['bindDNpassword'] = proc { CernerSplunk.splunk_encrypt_password password, node.run_state['cerner_splunk']['splunk.secret'] }
     end
 
     # Verify Attributes

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -33,6 +33,11 @@ MASTER_ONLY_CONFIGS = %w(
   commit_retry_time
 ).freeze
 
+# default pass4SymmKey value is 'changeme'
+server_stanzas['general']['pass4SymmKey'] = proc { CernerSplunk.splunk_encrypt_password 'changeme', node.run_state['cerner_splunk']['splunk.secret'] }
+# default sslKeysfilePassword value is 'password'
+server_stanzas['sslConfig']['sslKeysfilePassword'] = proc { CernerSplunk.splunk_encrypt_password 'password', node.run_state['cerner_splunk']['splunk.secret'], false }
+
 case node['splunk']['node_type']
 when :search_head, :server
   clusters = CernerSplunk.all_clusters(node).collect do |(cluster, bag)|
@@ -45,7 +50,9 @@ when :search_head, :server
 
     server_stanzas[stanza] = {}
     server_stanzas[stanza]['master_uri'] = master_uri
-    server_stanzas[stanza]['pass4SymmKey'] = pass unless pass.empty?
+
+    server_stanzas[stanza]['pass4SymmKey'] = proc { CernerSplunk.splunk_encrypt_password pass, node.run_state['cerner_splunk']['splunk.secret'] } unless pass.empty?
+
     # Until we support multisite clusters, set multisite explicitly false
     server_stanzas[stanza]['multisite'] = false
     stanza
@@ -159,20 +166,6 @@ server_stanzas['license'] = {
 }
 
 splunk_template 'system/server.conf' do
-  stanzas do
-    old_stanzas = CernerSplunk::Conf::Reader.new("#{node['splunk']['home']}/etc/system/local/server.conf").read
-
-    old_stanzas.each do |key, value|
-      case key
-      when 'general'
-        server_stanzas['general']['guid'] = value['guid'] if value['guid']
-        server_stanzas['general']['pass4SymmKey'] = value['pass4SymmKey'] if value['pass4SymmKey']
-      when 'sslConfig'
-        server_stanzas['sslConfig']['sslKeysfilePassword'] = value['sslKeysfilePassword']
-      end
-    end
-
-    server_stanzas
-  end
+  stanzas server_stanzas
   notifies :restart, 'service[splunk]'
 end

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -79,6 +79,13 @@ execute 'splunk-first-run' do
   only_if { ::File.exist? "#{node['splunk']['home']}/ftr" }
 end
 
+ruby_block 'read splunk.secret' do
+  block do
+    node.run_state['cerner_splunk'] ||= {}
+    node.run_state['cerner_splunk']['splunk.secret'] = ::File.open(::File.join(node['splunk']['home'], 'etc/auth/splunk.secret'), 'r') { |file| file.readline.chomp }
+  end
+end
+
 directory node['splunk']['external_config_directory'] do
   owner node['splunk']['user']
   group node['splunk']['group']

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -1,0 +1,30 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+require 'splunk_password'
+require 'rc4'
+
+describe 'CernerSplunk::splunk_password' do
+  let(:splunk_secret) { 'this_is_the_splunk_secret_key' }
+  let(:password) { 'password' }
+
+  describe '.splunk_decrypt_password' do
+    context 'when decrypting an encrypted password' do
+      subject { CernerSplunk.splunk_encrypt_password(password, splunk_secret) }
+      let(:decrypted_password) { CernerSplunk.splunk_decrypt_password(subject, splunk_secret) }
+
+      it 'results in the original value' do
+        expect(decrypted_password).to eq(password)
+      end
+    end
+
+    context 'when decrypting an encrypted sslconfig password' do
+      subject { CernerSplunk.splunk_encrypt_password(password, splunk_secret, false) }
+      let(:decrypted_password) { CernerSplunk.splunk_decrypt_password(subject, splunk_secret, false) }
+
+      it 'results in the original value' do
+        expect(decrypted_password).to eq(password)
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -186,6 +186,10 @@ describe 'cerner_splunk::_install' do
     end
   end
 
+  it 'runs ruby block read splunk.secret' do
+    expect(subject).to run_ruby_block('read splunk.secret')
+  end
+
   it 'creates external config directory' do
     expected_attrs = {
       owner: 'splunk',


### PR DESCRIPTION
This enhancement will support writing Splunk encrypted passwords in the config files.

## Why ?
Splunk encrypts passwords written in the config files. This causes Chef to detect a password which is different from what was written before causing Splunk to restart (to reflect the change). Writing the encrypted passwords into the conf file will prevent this restart from happening every time.  