### PR TITLE
Allow specification of index size in MB per day

### DIFF
--- a/docs/databags.md
+++ b/docs/databags.md
@@ -18,6 +18,7 @@ The Cluster Hash is part of a plaintext data bag item that defines a logical gro
 * `['master_uri']` - SplunkAPI URI of the cluster master (Required for servers connecting to managed clusters)
 * `['settings']` -  Hash of Cluster settings (Required for servers connecting to managed clusters),
 * `['settings'][???]` - Valid values are those under the clustering stanza of [server.conf][]
+* `['settings'][???]['_cerner_splunk_indexer_count']` - The number of indexers to use for calculating maxTotalDataSizeMB for each index in combination with _maxDailyDataSizeMB in the index configuration.
 * `['replication_ports']` - Configuration for cluster slave replication ports (required for cluster slaves)
 * `['replication_ports']['###']` - Port number to listen on
 * `['replication_ports']['###']['_cerner_splunk_ssl']` - boolean if the port is ssl enabled (false)
@@ -48,6 +49,8 @@ An Indexes Hash is part of a plaintext data bag item that defines the set of ind
 * `['config']` - These define the [indexes.conf] stanzas (in fairly raw form). However there are a few special keys:
     * `_volume` - The base volume for the coldPath, homePath and tstatsHomePath. Defaults to nil, so the index will be located in $SPLUNK_DB.
     * `_directory_name` - The on-disk name of the directory to store the index. Defaults to the index name.
+    * `_maxDailyDataSizeMB` - The amount of daily usage this index is expected to consume.  Used to calculate the maxTotalDataSizeMB if maxTotalDataSizeMB has not already been specified for the index.
+    * `_dataSizePaddingPercent` - The percentage of padding to apply to the amount of space this index is expected to consume.  Used to calculate the maxTotalDataSizeMB if maxTotalDataSizeMB has not already been specified for the index. Defaults to 10 if no value is specified.
 * `['flags']` - These define boolean processing flags per index. All flags are default 'false' but can be set to true. Current flags include:
     * `noGeneratePaths` - Do not generate the homePath,coldPath,thawedPath to this index when not present in the config above
     * `noRepFactor` - Do not add 'repFactor = auto' to this index when not present in the config on a cluster master.

--- a/recipes/_configure_indexes.rb
+++ b/recipes/_configure_indexes.rb
@@ -36,6 +36,25 @@ index_stanzas = config.inject({}) do |result, (stanza, index_config)|
       :index
     end
 
+  daily_mb = hash.delete('_maxDailyDataSizeMB')
+  padding = hash.delete('_dataSizePaddingPercent')
+  if [:index, :default].include?(stanza_type) && daily_mb && !hash.key?('maxTotalDataSizeMB')
+    settings = CernerSplunk.my_cluster_data(node).fetch('settings', {})
+    replication_factor = settings['replication_factor'] || 1
+    indexer_count = settings['_cerner_splunk_indexer_count'] || 1
+
+    default_config = config.fetch('default', {})
+
+    # If the frozen time isn't specified, splunk defaults to 6 years
+    frozen_time_in_secs = hash['frozenTimePeriodInSecs'] || default_config['frozenTimePeriodInSecs'] || 188_697_600
+    frozen_time_in_days = frozen_time_in_secs / 86_400
+
+    padding ||= default_config['_dataSizePaddingPercent']
+    padding = padding.nil? ? 1.1 : 1 + (padding / 100.0)
+
+    hash['maxTotalDataSizeMB'] = (daily_mb * padding * frozen_time_in_days * replication_factor).to_i / indexer_count
+  end
+
   if stanza_type == :index
     unless index_flags['noGeneratePaths']
       volume = hash.delete('_volume')

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -65,7 +65,7 @@ when :search_head, :server
   end
 when :cluster_master
   bag = CernerSplunk.my_cluster_data(node)
-  settings = (bag['settings'] || {}).delete_if do |k, _|
+  settings = (bag['settings'] || {}).reject do |k, _|
     k.start_with?('_cerner_splunk') || SLAVE_ONLY_CONFIGS.include?(k)
   end
 
@@ -75,7 +75,7 @@ when :cluster_slave
   cluster, bag = CernerSplunk.my_cluster(node)
   master_uri = bag['master_uri'] || ''
   replication_ports = bag['replication_ports'] || {}
-  settings = (bag['settings'] || {}).delete_if do |k, _|
+  settings = (bag['settings'] || {}).reject do |k, _|
     k.start_with?('_cerner_splunk') || MASTER_ONLY_CONFIGS.include?(k)
   end
 
@@ -89,7 +89,7 @@ when :cluster_slave
   replication_ports.each do |port, port_settings|
     ssl = port_settings['_cerner_splunk_ssl'] == true
     stanza = ssl ? "replication_port-ssl://#{port}" : "replication_port://#{port}"
-    server_stanzas[stanza] = port_settings.delete_if do |k, _|
+    server_stanzas[stanza] = port_settings.reject do |k, _|
       k.start_with? '_cerner_splunk'
     end
   end

--- a/spec/unit/recipes/_configure_indexes_spec.rb
+++ b/spec/unit/recipes/_configure_indexes_spec.rb
@@ -15,24 +15,16 @@ describe 'cerner_splunk::_configure_indexes' do
     {
       'receivers' => ['33.33.33.20'],
       'license_uri' => nil,
+      'settings' => {
+        'replication_factor' => 2,
+        '_cerner_splunk_indexer_count' => 3
+      },
       'receiver_settings' => {
         'splunktcp' => {
           'port' => '9997'
         }
       },
       'indexes' => 'cerner_splunk/indexes'
-    }
-  end
-
-  let(:index_config) do
-    {
-      'config' => {
-        'volume:test' => {
-          'path' => '/test/path'
-        },
-        'index_a' => { '_directory_name' => 'foo' },
-        'index_b' => { '_volume' => 'test' }
-      }
     }
   end
 
@@ -45,24 +37,103 @@ describe 'cerner_splunk::_configure_indexes' do
     CernerSplunk.reset
   end
 
-  it 'writes the indexes.conf file' do
-    expected_attributes = {
-      stanzas: {
-        'volume:test' => index_config['config']['volume:test'],
-        'index_a' => {
-          'coldPath' => '$SPLUNK_DB/foo/colddb',
-          'homePath' => '$SPLUNK_DB/foo/db',
-          'thawedPath' => '$SPLUNK_DB/foo/thaweddb'
-        },
-        'index_b' => {
-          'coldPath' => 'volume:test/index_b/colddb',
-          'homePath' => 'volume:test/index_b/db',
-          'thawedPath' => '$SPLUNK_DB/index_b/thaweddb',
-          'tstatsHomePath' => 'volume:test/index_b/datamodel_summary'
+  context 'when volumes and directory names are configured' do
+    let(:index_config) do
+      {
+        'config' => {
+          'volume:test' => {
+            'path' => '/test/path'
+          },
+          'index_a' => { '_directory_name' => 'foo' },
+          'index_b' => { '_volume' => 'test' }
         }
       }
-    }
+    end
 
-    expect(subject).to create_splunk_template('system/indexes.conf').with(expected_attributes)
+    it 'writes the indexes.conf file with the proper paths' do
+      expected_attributes = {
+        stanzas: {
+          'volume:test' => index_config['config']['volume:test'],
+          'index_a' => {
+            'coldPath' => '$SPLUNK_DB/foo/colddb',
+            'homePath' => '$SPLUNK_DB/foo/db',
+            'thawedPath' => '$SPLUNK_DB/foo/thaweddb'
+          },
+          'index_b' => {
+            'coldPath' => 'volume:test/index_b/colddb',
+            'homePath' => 'volume:test/index_b/db',
+            'thawedPath' => '$SPLUNK_DB/index_b/thaweddb',
+            'tstatsHomePath' => 'volume:test/index_b/datamodel_summary'
+          }
+        }
+      }
+
+      expect(subject).to create_splunk_template('system/indexes.conf').with(expected_attributes)
+    end
+  end
+
+  context 'when _maxDailyDataSizeMB is provided' do
+    let(:index_config) do
+      {
+        'config' => {
+          'default' => {
+            '_maxDailyDataSizeMB' => 100,
+            'frozenTimePeriodInSecs' => 2_592_000 # 30 days
+          },
+          'index_a' => {
+            '_maxDailyDataSizeMB' => 100,
+            'maxTotalDataSizeMB' => 1000
+          },
+          'index_b' => {
+            '_maxDailyDataSizeMB' => 25
+          },
+          'index_c' => {
+            '_maxDailyDataSizeMB' => 25,
+            'frozenTimePeriodInSecs' => 86_400
+          },
+          'index_d' => {
+            '_maxDailyDataSizeMB' => 100,
+            '_dataSizePaddingPercent' => 25
+          },
+          'index_e' => {
+            '_dataSizePaddingPercent' => 50
+          }
+        },
+        'flags' => {
+          'index_a' => { 'noGeneratePaths' => true },
+          'index_b' => { 'noGeneratePaths' => true },
+          'index_c' => { 'noGeneratePaths' => true },
+          'index_d' => { 'noGeneratePaths' => true },
+          'index_e' => { 'noGeneratePaths' => true }
+        }
+      }
+    end
+
+    it 'writes the indexes.conf file with calculated maxTotalDataSizeMB' do
+      expected_attributes = {
+        stanzas: {
+          'default' => {
+            'frozenTimePeriodInSecs' => 2_592_000,
+            'maxTotalDataSizeMB' => 2200
+          },
+          'index_a' => {
+            'maxTotalDataSizeMB' => 1000
+          },
+          'index_b' => {
+            'maxTotalDataSizeMB' => 550
+          },
+          'index_c' => {
+            'frozenTimePeriodInSecs' => 86_400,
+            'maxTotalDataSizeMB' => 18
+          },
+          'index_d' => {
+            'maxTotalDataSizeMB' => 2500
+          },
+          'index_e' => {}
+        }
+      }
+
+      expect(subject).to create_splunk_template('system/indexes.conf').with(expected_attributes)
+    end
   end
 end

--- a/spec/unit/recipes/heavy_forwarder_spec.rb
+++ b/spec/unit/recipes/heavy_forwarder_spec.rb
@@ -35,6 +35,10 @@ describe 'cerner_splunk::heavy_forwarder' do
     allow(Dir).to receive(:exist?).with('/opt/splunkforwarder').and_return(splunk_installed)
   end
 
+  after do
+    CernerSplunk.reset
+  end
+
   context 'when splunkforwarder is installed' do
     let(:splunk_installed) { true }
 

--- a/vagrant_repo/data_bags/cerner_splunk/cluster-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/cluster-vagrant.json
@@ -3,7 +3,8 @@
   "master_uri": "https://33.33.33.11:8089",
   "settings": {
     "replication_factor" : 2,
-    "search_factor" : 2
+    "search_factor" : 2,
+    "_cerner_splunk_indexer_count": 3
   },
   "replication_ports": {
     "8080" : { }

--- a/vagrant_repo/data_bags/cerner_splunk/indexes-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/indexes-vagrant.json
@@ -25,6 +25,7 @@
     "opsinfra" : { "_volume": "foo" },
     "pop_health" : { "_volume": "bar" },
     "bobs_index_emporium": {},
+    "calculated_max_total": { "_maxDailyDataSizeMB": 50 },
     "summary": { "maxTotalDataSizeMB": 500000 }
   },
   "flags": {


### PR DESCRIPTION
To make the calculation of maxTotalDataSizeMB a little more intuitive, this allows a value in MB per day to be specified in the data bag and the maxTotal index size will be calculated based on that value along with the other cluster size values.