### PR TITLE
Fix character encoding issues during RC4 encryption

### DIFF
--- a/libraries/rc4.rb
+++ b/libraries/rc4.rb
@@ -38,16 +38,12 @@ module CernerSplunk
     end
 
     def encrypt!(text)
-      index = 0
-      while index < text.length
+      text.force_encoding('binary').unpack('C*').map do |encoded_byte|
         @q1 = (@q1 + 1) % 256
         @q2 = (@q2 + @state[@q1]) % 256
         @state[@q1], @state[@q2] = @state[@q2], @state[@q1]
-        text.setbyte(index, text.getbyte(index) ^ @state[
-        (@state[@q1] + @state[@q2]) % 256])
-        index += 1
-      end
-      text
+        encoded_byte ^ @state[(@state[@q1] + @state[@q2]) % 256]
+      end.pack 'C*'
     end
 
     alias decrypt! encrypt!
@@ -67,9 +63,10 @@ module CernerSplunk
     def initialize_state(key)
       i = j = 0
       @state = INITIAL_STATE.dup
+      key = key.force_encoding('binary').unpack('C*')
       key_length = key.length
       while i < 256
-        j = (j + @state[i] + key.getbyte(i % key_length)) % 256
+        j = (j + @state[i] + key[i % key_length]) % 256
         @state[i], @state[j] = @state[j], @state[i]
         i += 1
       end

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -5,7 +5,7 @@ require 'splunk_password'
 require 'rc4'
 
 describe 'CernerSplunk::splunk_password' do
-  let(:splunk_secret) { 'this_is_the_splunk_secret_key' }
+  let(:splunk_secret) { 'qYFEHts8G0E/ABbp' }
   let(:password) { 'password' }
 
   describe '.splunk_decrypt_password' do


### PR DESCRIPTION
PR to fix the issue identified in https://github.com/cerner/cerner_splunk/issues/125.

Reading about character encoding, this seems to be the best way to fix issues with any type of character encoding (force_encoding to binary and then use the ASCII vs just taking the bytes). There is also PR open by someone to the Ruby-RC4 project to fix it.

This update fixed the issue with sslConfig and pass4SymmKey passwords that I was experiencing while working on https://github.com/cerner/cerner_splunk/pull/124.