### PR TITLE
Take rubocop back down a peg

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Style/NumericPredicate:
 
 Style/TernaryParentheses:
   Enabled: false
+
+Style/VariableNumber:
+  Enabled: false


### PR DESCRIPTION
Rubocop's release on Monday introduced an enforcement of style of variables with numbers in their names... bbatsov/rubocop#3167 which promptly caused the [latest stable merge to fail](https://travis-ci.org/cerner/cerner_splunk/builds/161359413).

IMHO such an enforcement beyond the simplest of code requires too much parsing of semantic meaning to be able to implement properly in a quick cop. Pick a style and try to sensibly enforce it with variable names referencing names of things or multiple named indexes `tls1_1`, `sha256`, `PKCS1-v1_5` or `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384` (normal comes closest, but even still there are cracks... )

So remember ![only you can kill it with fire](http://i3.kym-cdn.com/entries/icons/facebook/000/000/261/kill_it_with_fire_square.jpg)
