### PR TITLE
Splunk 6.5.2 upgrade and point heavy forwarder to license master.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,10 @@ source 'https://supermarket.chef.io'
 
 metadata
 
+case RUBY_VERSION
+when '2.1.6'
+  # build-essential >=8.0.0 requires chef 12.5+
+  cookbook 'build-essential', '< 8.0.0'
+end
+
 cookbook 'cerner_splunk_test', path: 'spec/cookbooks/cerner_splunk_test'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,8 @@ fail 'Non-unique hostnames' if @network.collect { |_, v| v[:hostname] }.uniq!
 fail 'Non-unique ports' if @network.collect { |_, v| v[:ports].keys }.flat_map { |v| v }.uniq!
 
 def default_omnibus(config)
+  # https://github.com/cerner/cerner_splunk/issues/141
+  # config.omnibus.chef_version = :latest
   config.omnibus.chef_version = '12.17.44'
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ fail 'Non-unique hostnames' if @network.collect { |_, v| v[:hostname] }.uniq!
 fail 'Non-unique ports' if @network.collect { |_, v| v[:ports].keys }.flat_map { |v| v }.uniq!
 
 def default_omnibus(config)
-  config.omnibus.chef_version = :latest
+  config.omnibus.chef_version = '12.17.44'
 end
 
 def network(config, name, splunk_password = true)

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -30,3 +30,6 @@ default['splunk']['apps'] = {}
 default['splunk']['flags']['index_checks_fail'] = true
 
 default['splunk']['config']['assumed_index'] = 'main'
+
+# Attribute used to point a heavy forwarder to license master
+default['splunk']['heavy_forwarder']['use_license_uri'] = false

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -10,8 +10,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '6.3.8'
-default['splunk']['package']['build'] = '1e8d95973e45'
+default['splunk']['package']['version'] = '6.5.2'
+default['splunk']['package']['build'] = '67571ef4b87d'
 
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`6.3.8`)
-* `node['splunk']['package']['build']` - Corresponding build number (`1e8d95973e45`)
+* `node['splunk']['package']['version']` - Major version to install (`6.5.2`)
+* `node['splunk']['package']['build']` - Corresponding build number (`67571ef4b87d`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -40,6 +40,7 @@ Configurable (with defaults)
 * `node['splunk']['config']['assumed_index']` - Name of the index to which data is forwarded to by default, when the index is not configured for the input.(`main`)
 * `node['splunk']['bootstrap_shc_member']` - Set this attribute to `true` to bootstrap a member to the Search Head Cluster (SHC). (`false`)
 * `node['splunk']['mgmt_host']` - The host other SHC members use when connecting to the current node. You probably want a wrapper cookbook to override this. (`node['ipaddress']`)
+* `node['splunk']['heavy_forwarder']['use_license_uri']` - Set this attribute to `true` to point the Heavy Forwarder to the license master. (`false`)
 * `node['splunk']['flags']['index_checks_fail']` - If `true` raises an exception failing the chef run, when monitors are configured to be sent to non-existent indexes. If `false` logs a warning, but does not fail the chef run for the same condition.(`true`)
 * `node['splunk']['apps']` - An [apps hash](databags.md#apps-hash) of apps to configure locally. (Does not support downloading apps ... yet...)
 

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -14,8 +14,8 @@ Running with Vagrant
   * Host the root of your mirrored structure on port 8080 using a lightweight HTTP server such as the node package [http-server](https://npmjs.org/package/http-server)
   * Un-comment the `splunk-mirrors` role in the Vagrant file. (Do not check in this modification of your Vagrantfile)
   * Required files and sizes (assuming current cookbook versions)
-    * `splunk-6.3.8-1e8d95973e45-linux-2.6-x86_64.rpm` and `splunk-6.3.8-1e8d95973e45-linux-2.6-amd64.deb` ~ 137MB each
-    * `splunkforwarder-6.3.8-1e8d95973e45-linux-2.6-x86_64.rpm` and `splunkforwarder-6.3.8-1e8d95973e45-linux-2.6-amd64.deb` ~ 16MB each
+    * `splunk-6.5.2-67571ef4b87d-linux-2.6-x86_64.rpm` and `splunk-6.5.2-67571ef4b87d-linux-2.6-amd64.deb` ~ 216MB each
+    * `splunkforwarder-6.5.2-67571ef4b87d-linux-2.6-x86_64.rpm` and `splunkforwarder-6.5.2-67571ef4b87d-linux-2.6-amd64.deb` ~ 19MB each
 * `vagrant-omnibus` installer currently requires internet access to function.
 
 **Note**:

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -135,13 +135,19 @@ end
 # License Configuration
 license_uri =
   case node['splunk']['node_type']
-  when :forwarder, :license_server
+  when :license_server
     'self'
   when :cluster_master, :cluster_slave, :server, :search_head, :shc_search_head, :shc_captain, :shc_deployer
     if node['splunk']['free_license']
       'self'
     else
       CernerSplunk.my_cluster_data(node)['license_uri'] || 'self'
+    end
+  when :forwarder
+    if node['splunk']['package']['base_name'] == 'splunk' && node['splunk']['heavy_forwarder']['use_license_uri']
+      CernerSplunk.my_cluster_data(node)['license_uri'] || 'self'
+    else
+      'self'
     end
   end
 
@@ -166,12 +172,10 @@ license_group =
   when :server
     if node['splunk']['free_license']
       'Free'
+    elsif license_uri == 'self'
+      'Trial'
     else
-      if license_uri == 'self'
-        'Trial'
-      else
-        'Enterprise'
-      end
+      'Enterprise'
     end
   end
 

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -147,13 +147,19 @@ license_uri =
 
 license_group =
   case node['splunk']['node_type']
-  when :license_server, :cluster_master, :cluster_slave, :shc_search_head, :shc_captain, :shc_deployer
+  when :license_server
     'Enterprise'
+  when :cluster_master, :cluster_slave, :shc_search_head, :shc_captain, :shc_deployer
+    if license_uri == 'self'
+      'Trial'
+    else
+      'Enterprise'
+    end
   when :forwarder
     'Forwarder'
   when :search_head
     if license_uri == 'self'
-      'Enterprise'
+      'Trial'
     else
       'Forwarder'
     end
@@ -161,7 +167,11 @@ license_group =
     if node['splunk']['free_license']
       'Free'
     else
-      'Enterprise'
+      if license_uri == 'self'
+        'Trial'
+      else
+        'Enterprise'
+      end
     end
   end
 

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -36,7 +36,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-6.3.8-1e8d95973e45' }
+  let(:splunk_file) { 'splunkforwarder-6.5.2-67571ef4b87d' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -50,7 +50,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.3.8-1e8d95973e45-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.5.2-67571ef4b87d-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
This PR introduces the following changes.

1. Upgrades Splunk to 6.5.2. The upgrade was tested using vagrant. It was noticed during testing that on all instances except license server where master_uri is set to _self_ need to have active_group set to _Trial_ to leverage the enterprise(trial) features. 
2. Updates the _configure_server recipe so that the heavy forwarder now points to the license server so that it can leverage the enterprise features. 