### PR TITLE
Splunk 6.5.3

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -10,8 +10,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '6.5.2'
-default['splunk']['package']['build'] = '67571ef4b87d'
+default['splunk']['package']['version'] = '6.5.3'
+default['splunk']['package']['build'] = '36937ad027d4'
 
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`6.5.2`)
-* `node['splunk']['package']['build']` - Corresponding build number (`67571ef4b87d`)
+* `node['splunk']['package']['version']` - Major version to install (`6.5.3`)
+* `node['splunk']['package']['build']` - Corresponding build number (`36937ad027d4`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -13,9 +13,6 @@ Running with Vagrant
     * You can find URLs for Splunk packages at the [Splunk download page](http://splunk.com/download)
   * Host the root of your mirrored structure on port 8080 using a lightweight HTTP server such as the node package [http-server](https://npmjs.org/package/http-server)
   * Un-comment the `splunk-mirrors` role in the Vagrant file. (Do not check in this modification of your Vagrantfile)
-  * Required files and sizes (assuming current cookbook versions)
-    * `splunk-6.5.2-67571ef4b87d-linux-2.6-x86_64.rpm` and `splunk-6.5.2-67571ef4b87d-linux-2.6-amd64.deb` ~ 216MB each
-    * `splunkforwarder-6.5.2-67571ef4b87d-linux-2.6-x86_64.rpm` and `splunkforwarder-6.5.2-67571ef4b87d-linux-2.6-amd64.deb` ~ 19MB each
 * `vagrant-omnibus` installer currently requires internet access to function.
 
 **Note**:

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -38,7 +38,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-6.5.2-67571ef4b87d' }
+  let(:splunk_file) { 'splunkforwarder-6.5.3-36937ad027d4' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -52,7 +52,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.5.2-67571ef4b87d-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-6.5.3-36937ad027d4-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Yes we just tagged, to get onto Splunk 6.5.2, but 6.5.3 was released and has security patches to it.

For more information see: http://www.splunk.com/view/SP-CAAAPZ3