### PR TITLE
Update to use sslPassword instead of sslKeysfilePassword

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ fail 'Non-unique hostnames' if @network.collect { |_, v| v[:hostname] }.uniq!
 fail 'Non-unique ports' if @network.collect { |_, v| v[:ports].keys }.flat_map { |v| v }.uniq!
 
 def default_omnibus(config)
-  config.omnibus.chef_version = :latest
+  config.omnibus.chef_version = '12'
 end
 
 def network(config, name, splunk_password = true)

--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -8,7 +8,7 @@ require 'base64'
 # Module contains different functions to encrypt and decrypt splunk passwords
 module CernerSplunk
   # Encrypts the password before writing into config files. As of now all the passwords
-  # needs to be XORed except for the sslKeyFilePassword. The boolean
+  # needs to be XORed except for the sslKeyFilePassword / sslPassword. The boolean
   # parameter xor controls the XOR logic.
   def self.splunk_encrypt_password(plain_text, splunk_secret, xor = true)
     rc4key = splunk_secret.strip[0..15]
@@ -24,7 +24,7 @@ module CernerSplunk
   end
 
   # Decrypts the splunk passwords. As of now the encrypted passwords needs to be XORed
-  # to retrieve the plain_text for every password except the sslKeyFilePassword.
+  # to retrieve the plain_text for every password except the sslKeyFilePassword / sslPassword.
   # The boolean parameter xor controls the XOR logic.
   def self.splunk_decrypt_password(encryp_password, splunk_secret, xor = true)
     rc4key = splunk_secret.strip[0..15]

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -38,8 +38,8 @@ encrypt_noxor_password = CernerSplunk::ConfTemplate::Transform.splunk_encrypt no
 
 # default pass4SymmKey value is 'changeme'
 server_stanzas['general']['pass4SymmKey'] = CernerSplunk::ConfTemplate.compose encrypt_password, CernerSplunk::ConfTemplate::Value.constant(value: 'changeme')
-# default sslKeysfilePassword value is 'password'
-server_stanzas['sslConfig']['sslKeysfilePassword'] = CernerSplunk::ConfTemplate.compose encrypt_noxor_password, CernerSplunk::ConfTemplate::Value.constant(value: 'password')
+# default sslPassword value is 'password'
+server_stanzas['sslConfig']['sslPassword'] = CernerSplunk::ConfTemplate.compose encrypt_noxor_password, CernerSplunk::ConfTemplate::Value.constant(value: 'password')
 
 # Indexer Cluster Configuration
 case node['splunk']['node_type']


### PR DESCRIPTION
With the update to 6.5.x, apparently `sslKeysfilePassword` in server.conf was deprecated in favor of `sslPassword`