### PR TITLE
Remove index validation and cluster data bag validation for forwarders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ when '2.1.6'
 else
   # https://github.com/cerner/cerner_splunk/issues/142
   chef_version = '= 12.18.31'
+  gem 'molinillo', '~> 0.5.0'
 end
 
 gem 'berkshelf'

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -41,7 +41,6 @@ Configurable (with defaults)
 * `node['splunk']['bootstrap_shc_member']` - Set this attribute to `true` to bootstrap a member to the Search Head Cluster (SHC). (`false`)
 * `node['splunk']['mgmt_host']` - The host other SHC members use when connecting to the current node. You probably want a wrapper cookbook to override this. (`node['ipaddress']`)
 * `node['splunk']['heavy_forwarder']['use_license_uri']` - Set this attribute to `true` to point the Heavy Forwarder to the license master. (`false`)
-* `node['splunk']['flags']['index_checks_fail']` - If `true` raises an exception failing the chef run, when monitors are configured to be sent to non-existent indexes. If `false` logs a warning, but does not fail the chef run for the same condition.(`true`)
 * `node['splunk']['apps']` - An [apps hash](databags.md#apps-hash) of apps to configure locally. (Does not support downloading apps ... yet...)
 
 

--- a/libraries/lwrp.rb
+++ b/libraries/lwrp.rb
@@ -15,7 +15,7 @@ module CernerSplunk
   # Methods involved with augmenting the LWRP syntax / writing recipies
   module LWRP
     # Change a list of monitors to a hash of stanzas for writing to a config file
-    def self.convert_monitors(node, monitors, default_index = nil, base = {})
+    def self.convert_monitors(monitors, default_index = nil, base = {})
       all_stanzas = monitors.inject(base) do |stanzas, element|
         type = element['type'] || element[:type] || 'monitor'
         path = element['path'] || element[:path]
@@ -32,7 +32,7 @@ module CernerSplunk
         end
         stanzas
       end
-      validate_indexes(node, all_stanzas)
+      all_stanzas
     end
 
     # RESOURCE: extend CernerSplunk::LWRP::DelayableAttribute unless defined? delayable_attribute
@@ -66,49 +66,6 @@ module CernerSplunk
           end
         end
       end
-    end
-
-    # Validate the indexes to which data is being forwarded to
-    def self.validate_indexes(node, monitors) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
-      index_error = []
-      input_regex = /^(?:monitor|tcp|batch|udp|fifo|script|fschange)/
-
-      indexes = monitors.select { |key, _| input_regex.match(key) }.collect { |_, v| v['index'] || node['splunk']['config']['assumed_index'] }.uniq
-
-      CernerSplunk.all_clusters(node).each do |(cluster, data_bag)|
-        bag = CernerSplunk::DataBag.load(data_bag['indexes'], handle_load_failure: true)
-
-        # Check if the indexes is not listed in the cluster data bag
-        unless bag
-          Chef::Log.warn "The indexes in the cluster '#{cluster}' is not defined or could not be loaded, therefore index checks could not be performed"
-          next
-        end
-
-        indexes.each do |index|
-          # Check if the index is not defined in the data bag
-          unless bag['config'].key?(index)
-            index_error << "Index '#{index}' is not defined by chef in cluster '#{cluster}'"
-            next
-          end
-
-          index_states = %w[isReadOnly disabled deleted]
-
-          index_states.each do |state|
-            value = bag['config'][index][state]
-            if value && %w[1 true].include?(value.to_s)
-              index_error << "Cannot forward data to index '#{index}' in the cluster '#{cluster}', because the index is marked as '#{state}'"
-            end
-          end
-        end
-      end
-
-      unless index_error.empty?
-        index_error_msg = "Data cannot be forwarded to respective index(es) due to the following reason(s):\n#{index_error.join("\n")}"
-        fail index_error_msg if node['splunk']['flags']['index_checks_fail']
-        Chef::Log.warn index_error_msg
-      end
-
-      monitors
     end
   end
 end

--- a/providers/forwarder_monitors.rb
+++ b/providers/forwarder_monitors.rb
@@ -11,7 +11,7 @@ provides :splunk_forwarder_monitors if respond_to?(:provides)
 provides :cerner_splunk_forwarder_monitors if respond_to?(:provides)
 
 action :install do
-  input_stanzas = CernerSplunk::LWRP.convert_monitors(node, new_resource.monitors, new_resource.index)
+  input_stanzas = CernerSplunk::LWRP.convert_monitors(new_resource.monitors, new_resource.index)
 
   file new_resource.app do
     action :nothing

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -7,7 +7,11 @@
 
 # Verify that clusters are configured
 if node['splunk']['node_type'] != :license_server && node['splunk']['config']['clusters'].empty?
-  throw 'You need to configure at least one cluster databag.'
+  if node['splunk']['node_type'] == :forwarder
+    Chef::Log.warn 'No cluster data bag configured, ensure your outputs are configured elsewhere.'
+  else
+    throw 'You need to configure at least one cluster databag.'
+  end
 end
 
 node['splunk']['config']['clusters'].each do |cluster|

--- a/recipes/_configure_inputs.rb
+++ b/recipes/_configure_inputs.rb
@@ -8,7 +8,7 @@
 # Translate monitor attributes to generic hash
 base_hash = { 'default' => { 'host' => node['splunk']['config']['host'] } }
 
-input_stanzas = CernerSplunk::LWRP.convert_monitors node, node['splunk']['monitors'], node['splunk']['main_project_index'], base_hash
+input_stanzas = CernerSplunk::LWRP.convert_monitors node['splunk']['monitors'], node['splunk']['main_project_index'], base_hash
 
 if %i[server cluster_slave].include? node['splunk']['node_type']
   bag = CernerSplunk.my_cluster_data(node)

--- a/spec/unit/recipes/_configure_spec.rb
+++ b/spec/unit/recipes/_configure_spec.rb
@@ -1,0 +1,87 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_configure' do
+  subject do
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+      node.override['splunk']['config']['clusters'] = clusters
+      node.override['splunk']['node_type'] = node_type
+    end
+    runner.converge('cerner_splunk::_restart_marker', described_recipe)
+  end
+
+  let(:node_type) { :server }
+
+  let(:cluster_config) do
+    {
+      'receivers' => ['33.33.33.20'],
+      'receiver_settings' => {
+        'splunktcp' => {
+          'port' => '9997'
+        }
+      },
+      'indexes' => 'cerner_splunk/indexes'
+    }
+  end
+
+  let(:clusters) { ['cerner_splunk/cluster'] }
+
+  before do
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'cluster').and_return(cluster_config)
+    allow(Chef::DataBagItem).to receive(:load).with('cerner_splunk', 'indexes').and_return({})
+  end
+
+  after do
+    CernerSplunk.reset
+  end
+
+  context 'when cluster databag is specified' do
+    it 'includes cerner_splunk::_configure_server recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_server')
+    end
+
+    it 'includes cerner_splunk::_configure_roles recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_roles')
+    end
+
+    it 'includes cerner_splunk::_configure_authentication recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_authentication')
+    end
+
+    it 'includes cerner_splunk::_configure_inputs recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_inputs')
+    end
+
+    it 'includes cerner_splunk::_configure_outputs recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_outputs')
+    end
+
+    it 'includes cerner_splunk::_configure_alerts recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_alerts')
+    end
+
+    it 'includes cerner_splunk::_configure_apps recipe' do
+      expect(subject).to include_recipe('cerner_splunk::_configure_apps')
+    end
+  end
+
+  context 'when cluster is not specified' do
+    let(:clusters) { [] }
+
+    context 'when node is a forwarder' do
+      let(:node_type) { :forwarder }
+
+      it 'should raise a warning message' do
+        expect(Chef::Log).to receive(:warn).with('No cluster data bag configured, ensure your outputs are configured elsewhere.')
+        subject
+      end
+    end
+
+    context 'when node is not a forwarder' do
+      it 'should raise an exception' do
+        expect { subject }.to raise_exception
+      end
+    end
+  end
+end


### PR DESCRIPTION
When we have all the configs (including the outputs.conf) packaged in an app and installed on a fowarder, we don't have to again specify the cluster databag for the forwarder. This PR updates the _configure recipe to log a warning if no cluster data bags are configured rather than throw an error.

@acharlieh also mentioned that we could remove the index check validation in this PR since it doesn't add much value today.