### PR TITLE
Add support for indexer discovery

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -150,7 +150,7 @@ Vagrant.configure('2') do |config|
   config.vm.define :c1_master do |cfg|
     default_omnibus config
     cfg.vm.provision :chef_client do |chef|
-      chef_defaults chef, :c1_master
+      chef_defaults chef, :c1_master, 'splunk_cluster_master'
       chef.add_recipe 'cerner_splunk::cluster_master'
     end
     network cfg, :c1_master

--- a/docs/databags.md
+++ b/docs/databags.md
@@ -30,6 +30,14 @@ The Cluster Hash is part of a plaintext data bag item that defines a logical gro
 * `['shc_replication_ports']` - identical as `['replication_ports']` but take precedence for Search Head Cluster members/captain when replication port settings need to differ between SHC members and indexer cluster slaves in the same cluster.
 * `['receivers']` - Array of strings of hosts where this cluster's indexers are listening. (Required for forwarders)
 * `['receiver_settings']['splunktcp']['port']` - Port indexers are listening on, and forwarders are sending data (required for forwarders and receivers)
+* `['tcpout_settings']` - Hash of tcpout settings to be configured in the outputs.conf under the `tcpout` stanza.
+* `['tcpout_settings'][???]` - Valid values are those under the tcpout stanza of [outputs.conf][]
+* `['indexer_discovery']` - Boolean to toggle indexer_discovery. Set this to `true` to leverage indexer discovery. Note that `['receivers']` configured when `['indexer_discovery']` is set to `true` will be ignored.
+* `['indexer_discovery_settings']['pass4SymmKey']` - pass4Symmkey value to be set under the `index_discovery` stanza in [server.conf][] and [outputs.conf][]
+* `['indexer_discovery_settings']['master_configs']` - Hash of indexer discovery settings to be configured on the cluster master under the `indexer_discovery` stanza.
+* `['indexer_discovery_settings']['master_configs'][???]` - Valid values are those under the indexer_discovery stanza of [server.conf][]
+* `['indexer_discovery_settings']['outputs_configs']` - Hash of indexer discovery settings to be configured in the outputs.conf under the `indexer_discovery` stanza.
+* `['indexer_discovery_settings']['outputs_configs'][???]` - Valid values are those under the indexer_discovery stanza of [outputs.conf][]
 * `['indexes']` - A String pointing to an indexes data bag hash. (Coordinate form as described above)
 * `['apps']` - A String pointing to an apps data bag hash. (Coordinate form as described above)
 
@@ -135,11 +143,12 @@ Docs Navigation
 * [Docs Readme](README.md)
 * [Repository Readme](../README.md)
 
-[server.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Serverconf
-[indexes.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Indexesconf
-[user-prefs.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/User-prefsconf
-[authorize.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Authorizeconf
-[authentication.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Authenticationconf
 [alert-actions.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Alert-actionsconf
-[default.meta]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Defaultmetaconf
 [app.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/appconf
+[authentication.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Authenticationconf
+[authorize.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Authorizeconf
+[default.meta]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Defaultmetaconf
+[indexes.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Indexesconf
+[outputs.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Outputsconf
+[server.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/Serverconf
+[user-prefs.conf]: http://docs.splunk.com/Documentation/Splunk/latest/Admin/User-prefsconf

--- a/libraries/conf_template.rb
+++ b/libraries/conf_template.rb
@@ -2,85 +2,86 @@
 
 # Cookbook Name:: cerner_splunk
 # File Name:: conf_template.rb
-
 module CernerSplunk
-  # Module for generating template data
-  module ConfTemplate
-    # Evaluate a Proc (or a Proc returning Procs)
-    def self.collapse_proc(initial, depth: 10, arguments: {}, label: nil)
-      value = initial
-      message_suffix = " evaluating #{label}" unless label.nil?
-      while value.is_a? Proc
-        fail "Proc depth exceeded#{message_suffix}" if depth <= 0
-        value = value.call(arguments)
-        depth -= 1
-      end
-      value
-    end
-
-    # Convert the stanzas argument into Hash of Hash of key value pairs
-    def self.convert_stanzas(input)
-      (CernerSplunk::ConfTemplate.collapse_proc input || {}).inject({}) do |file_data, (stanza, stanza_value)|
-        label = "Stanza #{stanza}"
-        stanza_value = CernerSplunk::ConfTemplate.collapse_proc stanza_value, label: label, arguments: { stanza: stanza }
-        fail "Unexpected value (#{stanza_value.class} '#{stanza_value}') for #{label}" unless stanza_value.nil? || stanza_value.is_a?(Hash)
-        if stanza_value.is_a? Hash
-          file_data[stanza] = stanza_value.inject({}) do |result, (attribute, value)|
-            label = "Attribute #{attribute}, Stanza #{stanza}"
-            value = CernerSplunk::ConfTemplate.collapse_proc value, label: label, arguments: { stanza: stanza, attribute: attribute }
-            result[attribute] = value unless value.nil?
-            result
-          end
+  unless defined?(ConfTemplate)
+    # Module for generating template data
+    module ConfTemplate
+      # Evaluate a Proc (or a Proc returning Procs)
+      def self.collapse_proc(initial, depth: 10, arguments: {}, label: nil)
+        value = initial
+        message_suffix = " evaluating #{label}" unless label.nil?
+        while value.is_a? Proc
+          fail "Proc depth exceeded#{message_suffix}" if depth <= 0
+          value = value.call(arguments)
+          depth -= 1
         end
-        file_data
-      end
-    end
-
-    # Compose two procs... I should monkey patch this in, but changing core ruby just seems wrong
-    def self.compose(g, f)
-      proc { |*a| g[*f[*a]] }
-    end
-
-    # Class to cache the read of a conf file's existing contents
-    class ExistingValue
-      def initialize(filename)
-        @reader = CernerSplunk::Conf::Reader.new filename
+        value
       end
 
-      def [](x)
-        data[x]
+      # Convert the stanzas argument into Hash of Hash of key value pairs
+      def self.convert_stanzas(input)
+        (CernerSplunk::ConfTemplate.collapse_proc input || {}).inject({}) do |file_data, (stanza, stanza_value)|
+          label = "Stanza #{stanza}"
+          stanza_value = CernerSplunk::ConfTemplate.collapse_proc stanza_value, label: label, arguments: { stanza: stanza }
+          fail "Unexpected value (#{stanza_value.class} '#{stanza_value}') for #{label}" unless stanza_value.nil? || stanza_value.is_a?(Hash)
+          if stanza_value.is_a? Hash
+            file_data[stanza] = stanza_value.inject({}) do |result, (attribute, value)|
+              label = "Attribute #{attribute}, Stanza #{stanza}"
+              value = CernerSplunk::ConfTemplate.collapse_proc value, label: label, arguments: { stanza: stanza, attribute: attribute }
+              result[attribute] = value unless value.nil?
+              result
+            end
+          end
+          file_data
+        end
       end
 
-      def data
-        @data ||= @reader.read
-      end
-    end
-
-    # Methods to generate procs for determining the value to be written to a conf file
-    module Value
-      def self.constant(value:, **_)
-        proc { value }
+      # Compose two procs... I should monkey patch this in, but changing core ruby just seems wrong
+      def self.compose(g, f)
+        proc { |*a| g[*f[*a]] }
       end
 
-      def self.vault(coordinate:, default_coords: nil, pick_context: nil, node:, **_)
-        proc { CernerSplunk::DataBag.load coordinate, secret: node['splunk']['data_bag_secret'], default: default_coords, pick_context: pick_context }
+      # Class to cache the read of a conf file's existing contents
+      class ExistingValue
+        def initialize(filename)
+          @reader = CernerSplunk::Conf::Reader.new filename
+        end
+
+        def [](x)
+          data[x]
+        end
+
+        def data
+          @data ||= @reader.read
+        end
       end
 
-      def self.existing(filename:, **_)
-        @file_readers ||= Hash.new { |hash, key| hash[key] = CernerSplunk::ConfTemplate.ExistingValue.new key }
-        existing_value = @file_readers[filename]
-        proc { |stanza:, attribute: nil, **_| attribute.nil? ? existing_value[stanza] : (existing_value[stanza] || {})[attribute] }
-      end
-    end
+      # Methods to generate procs for determining the value to be written to a conf file
+      module Value
+        def self.constant(value:, **_)
+          proc { value }
+        end
 
-    # Methods to generate procs for how to transform the value prior to writing.
-    module Transform
-      def self.id(**_)
-        proc { |x| x }
+        def self.vault(coordinate:, default_coords: nil, pick_context: nil, node:, **_)
+          proc { CernerSplunk::DataBag.load coordinate, secret: node['splunk']['data_bag_secret'], default: default_coords, pick_context: pick_context }
+        end
+
+        def self.existing(filename:, **_)
+          @file_readers ||= Hash.new { |hash, key| hash[key] = CernerSplunk::ConfTemplate.ExistingValue.new key }
+          existing_value = @file_readers[filename]
+          proc { |stanza:, attribute: nil, **_| attribute.nil? ? existing_value[stanza] : (existing_value[stanza] || {})[attribute] }
+        end
       end
 
-      def self.splunk_encrypt(node:, xor: true, **_)
-        proc { |x| CernerSplunk.splunk_encrypt_password(x, node.run_state['cerner_splunk']['splunk.secret'], xor) if x }
+      # Methods to generate procs for how to transform the value prior to writing.
+      module Transform
+        def self.id(**_)
+          proc { |x| x }
+        end
+
+        def self.splunk_encrypt(node:, xor: true, **_)
+          proc { |x| CernerSplunk.splunk_encrypt_password(x, node.run_state['cerner_splunk']['splunk.secret'], xor) if x }
+        end
       end
     end
   end

--- a/libraries/outputs.rb
+++ b/libraries/outputs.rb
@@ -8,7 +8,7 @@ require_relative 'databag'
 module CernerSplunk
   # Module contains functions to configure outputs.conf in a Splunk system
   module Outputs
-    def self.configure_outputs(node) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    def self.configure_outputs(node) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
       output_stanzas = {}
 
       if %i[search_head forwarder cluster_master shc_deployer].include? node['splunk']['node_type']
@@ -24,6 +24,31 @@ module CernerSplunk
         else
           [CernerSplunk.my_cluster(node)]
         end.each do |(cluster, bag)|
+          if bag['indexer_discovery'] == true
+            Chef::Log.warn "Configured ['receivers'] in cluster #{cluster} will be ignored since ['indexer_discovery'] is set to true." if bag['receivers']
+
+            indexer_discovery_settings = ((bag['indexer_discovery_settings'] && bag['indexer_discovery_settings']['outputs_configs']) || {}).reject do |k, _|
+              k.start_with?('_cerner_splunk')
+            end
+            output_stanzas["indexer_discovery:#{cluster}"] = indexer_discovery_settings
+
+            fail "master_uri is missing in the cluster databag: #{cluster}" if bag['master_uri'].nil? || bag['master_uri'].empty?
+
+            output_stanzas["indexer_discovery:#{cluster}"]['master_uri'] = bag['master_uri']
+            encrypt_password = CernerSplunk::ConfTemplate::Transform.splunk_encrypt node: node
+
+            pass =
+              if bag['indexer_discovery_settings'] && bag['indexer_discovery_settings']['pass4SymmKey']
+                bag['indexer_discovery_settings']['pass4SymmKey']
+              else
+                'changeme'
+              end
+            output_stanzas["indexer_discovery:#{cluster}"]['pass4SymmKey'] = CernerSplunk::ConfTemplate.compose encrypt_password, CernerSplunk::ConfTemplate::Value.constant(value: pass)
+            output_stanzas["tcpout:#{cluster}"] = bag['tcpout_settings'] || {}
+            output_stanzas["tcpout:#{cluster}"]['indexerDiscovery'] = cluster
+            next
+          end
+
           port = bag['receiver_settings']
           port = port['splunktcp'] if port
           port = port['port'] if port
@@ -32,7 +57,7 @@ module CernerSplunk
           if !receivers || receivers.empty? || !port
             Chef::Log.warn "Receiver settings missing or incomplete in configured cluster data bag: #{cluster}"
           else
-            output_stanzas["tcpout:#{cluster}"] = {}
+            output_stanzas["tcpout:#{cluster}"] = bag['tcpout_settings'] || {}
             output_stanzas["tcpout:#{cluster}"]['server'] = receivers.collect do |x|
               x.include?(':') ? x : "#{x}:#{port}"
             end.join(',')

--- a/recipes/_configure_inputs.rb
+++ b/recipes/_configure_inputs.rb
@@ -11,15 +11,14 @@ base_hash = { 'default' => { 'host' => node['splunk']['config']['host'] } }
 input_stanzas = CernerSplunk::LWRP.convert_monitors node['splunk']['monitors'], node['splunk']['main_project_index'], base_hash
 
 if %i[server cluster_slave].include? node['splunk']['node_type']
-  bag = CernerSplunk.my_cluster_data(node)
+  cluster, bag = CernerSplunk.my_cluster(node)
   port = bag['receiver_settings']
   port = port['splunktcp'] if port
   port = port['port'] if port
-
   if port
-    input_stanzas["splunktcp://:#{port}"] = {}
-    input_stanzas["splunktcp://:#{port}"]['disabled'] = 0
-    input_stanzas["splunktcp://:#{port}"]['connection_host'] = 'none'
+    input_stanzas["splunktcp://#{port}"] = {}
+    input_stanzas["splunktcp://#{port}"]['disabled'] = 0
+    input_stanzas["splunktcp://#{port}"]['connection_host'] = 'none'
   else
     Chef::Log.warn "Receiver settings missing in configured cluster data bag: #{cluster}"
   end

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -75,6 +75,17 @@ when :cluster_master
 
   server_stanzas['clustering'] = settings
   server_stanzas['clustering']['mode'] = 'master'
+
+  if bag['indexer_discovery'] == true
+    indexer_discovery_settings = ((bag['indexer_discovery_settings'] && bag['indexer_discovery_settings']['master_configs']) || {}).reject do |k, _|
+      k.start_with?('_cerner_splunk')
+    end
+    pass = (bag['indexer_discovery_settings'] && bag['indexer_discovery_settings']['pass4SymmKey']) || nil
+
+    server_stanzas['indexer_discovery'] = indexer_discovery_settings
+    server_stanzas['indexer_discovery']['pass4SymmKey'] = CernerSplunk::ConfTemplate.compose encrypt_password, CernerSplunk::ConfTemplate::Value.constant(value: pass) if pass
+  end
+
 when :cluster_slave
   cluster, bag = CernerSplunk.my_cluster(node)
   master_uri = bag['master_uri'] || ''

--- a/spec/unit/recipes/_configure_outputs_spec.rb
+++ b/spec/unit/recipes/_configure_outputs_spec.rb
@@ -1,0 +1,206 @@
+# coding: UTF-8
+
+require_relative '../spec_helper'
+
+shared_examples 'when receivers or port is not configured' do
+  it 'logs a warning' do
+    message = 'Receiver settings missing or incomplete in configured cluster data bag: cerner_splunk/cluster'
+    expect(Chef::Log).to receive(:warn).with(message)
+    subject
+  end
+end
+
+shared_examples 'when indexer discovery is set to true and master_uri is empty or not configured' do
+  it 'fails with an error' do
+    message = 'master_uri is missing in the cluster databag: cerner_splunk/indexer_discovery_configs'
+    expect { subject }.to raise_error(RuntimeError, message)
+  end
+end
+
+describe 'cerner_splunk::_configure_outputs' do
+  subject do
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+      node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster', 'cerner_splunk/indexer_discovery_configs']
+      node.override['splunk']['node_type'] = node_type
+    end
+    runner.converge('cerner_splunk::_restart_marker', described_recipe)
+  end
+
+  let(:receiver_list) { ['33.33.33.11', '33.33.33.12'] }
+  let(:receivers) { { 'receivers' => receiver_list } }
+  let(:port) { '9997' }
+
+  let(:cluster_config) do
+    {
+      'license_uri' => nil,
+      'tcpout_settings' => {
+        'autoLBFrequency' => 30
+      },
+      'receiver_settings' => {
+        'splunktcp' => {
+          'port' => port
+        }
+      }
+    }.merge(receivers)
+  end
+
+  let(:outputs_config_values) { {} }
+  let(:outputs_configs) { {} }
+
+  let(:indexer_discovery_settings) do
+    {
+      'pass4SymmKey' => 'fake_password'
+    }.merge(outputs_configs)
+  end
+
+  let(:indexer_discovery_config) do
+    {
+      'master_uri' => master_uri,
+      'indexer_discovery' => true,
+      'indexer_discovery_settings' => indexer_discovery_settings,
+      'tcpout_settings' => {
+        'useACK' => true,
+        'autoLBFrequency' => 30
+      }
+    }
+  end
+
+  let(:master_uri) { 'https://cluster-master:8089' }
+  let(:node_type) { :forwarder }
+
+  before do
+    allow(CernerSplunk::ConfTemplate).to receive(:compose).and_return('fake_password')
+    allow(ChefVault::Item).to receive(:data_bag_item_type).and_return(:normal)
+    stub_data_bag_item('cerner_splunk', 'cluster').and_return(cluster_config)
+    stub_data_bag_item('cerner_splunk', 'indexer_discovery_configs').and_return(indexer_discovery_config)
+    stub_data_bag_item('cerner_splunk', 'indexes').and_return({})
+  end
+
+  after do
+    CernerSplunk.reset
+  end
+
+  context 'when the node is forwarder' do
+    it 'writes the outputs.conf file with the appropriate configs for all the cluster databags' do
+      expected_attributes = {
+        stanzas: {
+          'tcpout' => {
+            'forwardedindex.0.whitelist' => '.*', 'forwardedindex.1.blacklist' => '_thefishbucket', 'forwardedindex.2.whitelist' => ''
+          },
+          'tcpout:cerner_splunk/cluster' => {
+            'server' => '33.33.33.11:9997,33.33.33.12:9997',
+            'autoLBFrequency' => 30
+          },
+          'tcpout:cerner_splunk/indexer_discovery_configs' => {
+            'useACK' => true,
+            'autoLBFrequency' => 30,
+            'indexerDiscovery' => 'cerner_splunk/indexer_discovery_configs'
+          },
+          'indexer_discovery:cerner_splunk/indexer_discovery_configs' => {
+            'master_uri' => 'https://cluster-master:8089',
+            'pass4SymmKey' => 'fake_password'
+          }
+        }
+      }
+      expect(subject).to create_splunk_template('system/outputs.conf').with(expected_attributes)
+      expect(subject.splunk_template('system/outputs.conf')).to notify('file[splunk-marker]').to(:touch)
+    end
+  end
+
+  context 'when the node is a search_head' do
+    let(:node_type) { :search_head }
+
+    context 'when receivers are configured' do
+      it 'writes the outputs.conf file with the appropriate configs only from my cluster' do
+        expected_attributes = {
+          stanzas: {
+            'tcpout' => {
+              'forwardedindex.0.whitelist' => '.*', 'forwardedindex.1.blacklist' => '_thefishbucket', 'forwardedindex.2.whitelist' => ''
+            },
+            'tcpout:cerner_splunk/cluster' => {
+              'server' => '33.33.33.11:9997,33.33.33.12:9997',
+              'autoLBFrequency' => 30
+            }
+          }
+        }
+        expect(subject).to create_splunk_template('system/outputs.conf').with(expected_attributes)
+        expect(subject.splunk_template('system/outputs.conf')).to notify('file[splunk-marker]').to(:touch)
+      end
+    end
+
+    context 'when receivers is an empty array' do
+      let(:receiver_list) { [] }
+
+      include_examples 'when receivers or port is not configured'
+    end
+
+    context 'when receivers is not configured' do
+      let(:receivers) { {} }
+
+      include_examples 'when receivers or port is not configured'
+    end
+
+    context 'when port is not configured' do
+      let(:port) {}
+
+      include_examples 'when receivers or port is not configured'
+    end
+  end
+
+  context 'when indexer_discovery is set to true and master_uri is not configured' do
+    context 'when master_uri is not set' do
+      let(:indexer_discovery_config) { { 'indexer_discovery' => true } }
+
+      include_examples 'when indexer discovery is set to true and master_uri is empty or not configured'
+    end
+
+    context 'when master_uri is empty' do
+      let(:master_uri) { '' }
+
+      include_examples 'when indexer discovery is set to true and master_uri is empty or not configured'
+    end
+  end
+
+  context 'when indexer_discovery is set to true' do
+    context 'when attributes are configured in outputs_config hash' do
+      let(:outputs_config_values) { { 'send_timeout' => 30, 'rcv_timeout' => 30 } }
+      let(:outputs_configs) { { 'outputs_configs' => outputs_config_values } }
+      expected_attributes = {
+        stanzas: {
+          'tcpout' => {
+            'forwardedindex.0.whitelist' => '.*', 'forwardedindex.1.blacklist' => '_thefishbucket', 'forwardedindex.2.whitelist' => ''
+          },
+          'tcpout:cerner_splunk/cluster' => {
+            'server' => '33.33.33.11:9997,33.33.33.12:9997',
+            'autoLBFrequency' => 30
+          },
+          'tcpout:cerner_splunk/indexer_discovery_configs' => {
+            'autoLBFrequency' => 30,
+            'useACK' => true,
+            'indexerDiscovery' => 'cerner_splunk/indexer_discovery_configs'
+          },
+          'indexer_discovery:cerner_splunk/indexer_discovery_configs' => {
+            'master_uri' => 'https://cluster-master:8089',
+            'pass4SymmKey' => 'fake_password',
+            'send_timeout' => 30,
+            'rcv_timeout' => 30
+          }
+        }
+      }
+      it 'writes the attributes to the indexer_discovery stanza' do
+        expect(subject).to create_splunk_template('system/outputs.conf').with(expected_attributes)
+        expect(subject.splunk_template('system/outputs.conf')).to notify('file[splunk-marker]').to(:touch)
+      end
+    end
+
+    context 'when receivers are configured' do
+      let(:indexer_discovery_config) { { 'indexer_discovery' => true, 'receivers' => ['33.33.33.11', '33.33.33.12'], 'master_uri' => master_uri } }
+
+      it 'logs a warning message' do
+        message = "Configured ['receivers'] in cluster cerner_splunk/indexer_discovery_configs will be ignored since ['indexer_discovery'] is set to true."
+        expect(Chef::Log).to receive(:warn).with(message)
+        subject
+      end
+    end
+  end
+end

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec'
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chef-vault'
+require 'conf_template'
 
 RSpec.configure do |config|
   config.order = 'random'

--- a/vagrant_repo/data_bags/cerner_splunk/cluster-indexer-discovery.json
+++ b/vagrant_repo/data_bags/cerner_splunk/cluster-indexer-discovery.json
@@ -1,0 +1,33 @@
+{
+  "id": "cluster-indexer-discovery",
+  "master_uri": "https://33.33.33.11:8089",
+  "settings": {
+    "replication_factor" : 2,
+    "search_factor" : 2,
+    "_cerner_splunk_indexer_count": 3
+  },
+  "indexer_discovery": true,
+  "indexer_discovery_settings" :{
+    "outputs_configs": {
+      "send_timeout": 30,
+      "rcv_timeout": 30
+    },
+    "master_configs": {
+      "indexerWeightByDiskCapacity": true
+    }
+  },
+  "tcpout_settings":{
+    "useACK": true
+  },
+  "license_uri": null,
+  "receiver_settings": {
+    "splunktcp": {
+      "port": 9997
+    }
+  },
+  "replication_ports": {
+    "8080" : { }
+  },
+  "indexes" : "cerner_splunk/indexes-vagrant",
+  "apps": "cerner_splunk/cluster-apps-vagrant"
+}

--- a/vagrant_repo/data_bags/cerner_splunk/cluster-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/cluster-vagrant.json
@@ -16,6 +16,9 @@
     "33.33.33.13",
     "33.33.33.14"
   ],
+  "tcpout_settings":{
+    "useACK": false
+  },
   "receiver_settings": {
     "splunktcp": {
       "port": 9997

--- a/vagrant_repo/environments/splunk_cluster_master.json
+++ b/vagrant_repo/environments/splunk_cluster_master.json
@@ -1,0 +1,13 @@
+{
+  "name": "splunk_cluster_master",
+  "description": "Separate environment for cluster master because it requires the databag with indexer discovery enabled",
+  "default_attributes": {
+    "splunk": {
+      "config": {
+        "clusters": [
+          "cerner_splunk/cluster-indexer-discovery"
+        ]
+      }
+    }
+  }
+}

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -9,7 +9,7 @@
       "config": {
         "clusters": [
           "cerner_splunk/cluster-standalone",
-          "cerner_splunk/cluster-vagrant"
+          "cerner_splunk/cluster-indexer-discovery"
         ],
         "roles": "cerner_splunk/authnz-vagrant:roles",
         "authentication": "cerner_splunk/authnz-vagrant:authn",


### PR DESCRIPTION
## What was changed? Why is this necessary?
This PR introduces support for indexer discovery.  http://docs.splunk.com/Documentation/Splunk/6.6.0/Indexer/indexerdiscovery

## How was it tested?
There are ChefSpecs included in this PR. Also, the vagrant set up is now updated so that the forwarder talks to the peers in the clustered setup using indexer discovery and to the standalone instance in the traditional way (where we list the peer IPs using the `servers` attribute in the `tcpout` stanza). 