### PR TITLE
Allow config for admin password and pass4SymmKey for all node types

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -33,7 +33,8 @@ Configurable (with defaults)
 * `node['splunk']['config']['authentication']` - Data bag item used to configure authentication (`nil` - authentication not managed by chef)
 * `node['splunk']['config']['host']` - Hostname to configure the Splunk instance to report as. (EC2 Instance ID or Fully Qualified Domain Name)
 * `node['splunk']['config']['roles']` - Data bag item used to configure roles (`nil` - roles not managed by chef)
-* `node['splunk']['config']['secrets']` - Coordinate String (see [data bags documentation][data_bags]), pointing to a key within a Chef Vault encrypted data bag item used to configure the splunk.secret file. The value must be a string. (`nil` - secrets not managed by chef).  Note: this is currently not supported on windows.
+* `node['splunk']['config']['secrets']` - A Contextual Hash of coordinate strings (see [data bags documentation][data_bags]), pointing to a key within a data bag item used to configure the splunk.secret file. (`nil` - secrets not managed by chef).  Note: this is currently not supported on windows.
+* `node['splunk']['config']['admin_password']` - A Contextual Hash of coordinate strings (see [data bags documentation][data_bags]), pointing to a key within a data bag item used to configure the local admin password. (`nil` - password is randomly generated and changed on every chef-client run).
 * `node['splunk']['config']['licenses']` - Data bag item that the license server recipe uses as the source of truth for the license data.
 * `node['splunk']['config']['license-pool']` - Data bag item used to configure license pools.
 * `node['splunk']['config']['ui_prefs']` - Hash of stanzas used to configure [ui-prefs.conf][] on the search head in a clustered configuration or a standalone instance.

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -21,7 +21,7 @@ After you spin up the cluster slaves you will have to restart the cluster master
 
 # Spinning up a Search Head Cluster in Vagrant
 
-<code>vagrant up /c2_.*/</code>
+`vagrant up /c2_.*/`
 
 c2_boot1 and c2_boot2 are the bootstrap nodes and are provisioned first. c2_captain is then provisioned and the cluster is established. c2_deployer is provisioned and pushes apps to the cluster. Finally c2_newnode is provisioned and joins the cluster as a scale up example.
 

--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -11,6 +11,9 @@ module CernerSplunk
   # needs to be XORed except for the sslPassword. The boolean
   # parameter xor controls the XOR logic.
   def self.splunk_encrypt_password(plain_text, splunk_secret, xor = true)
+    # Prevent double encrypting values
+    return plain_text if plain_text.start_with? '$1$'
+
     rc4key = splunk_secret.strip[0..15]
 
     password =

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -8,6 +8,17 @@ describe 'CernerSplunk::splunk_password' do
   let(:splunk_secret) { 'qYFEHts8G0E/ABbp' }
   let(:password) { 'password' }
 
+  describe '.splunk_encrypt_password' do
+    context 'when the password has already been encrypted' do
+      let(:password) { '$1$RhLQiUyG3Qc7' }
+
+      it 'does not re-encrypt it again' do
+        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
+        expect(encrypted).to eq(password)
+      end
+    end
+  end
+
   describe '.splunk_decrypt_password' do
     context 'when decrypting an encrypted password' do
       subject { CernerSplunk.splunk_encrypt_password(password, splunk_secret) }

--- a/vagrant_repo/data_bags/cerner_splunk/cluster-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/cluster-vagrant.json
@@ -31,7 +31,8 @@
   ],
   "shc_settings":{
     "replication_factor" : 2,
-    "shcluster_label": "main-cluster"
+    "shcluster_label": "main-cluster",
+    "pass4SymmKey": "$1$4SvBVSpNjhiY51BIRp6C3urG7YJU"
   },
   "indexes" : "cerner_splunk/indexes-vagrant",
   "apps": "cerner_splunk/cluster-apps-vagrant"

--- a/vagrant_repo/data_bags/cerner_splunk/standalone_passwords.json
+++ b/vagrant_repo/data_bags/cerner_splunk/standalone_passwords.json
@@ -1,8 +1,14 @@
 {
   "id": "standalone_passwords",
   "splunk.secret": {
-    "encrypted_data": "OEbl5nQOz5inoa+dOb7XxZqzL/j5iog1u9FRVkRWcrleJIRDzkKeMRTVguIN\n9yEd/IDq17+AHFiKKULcQv5BjPh07pCIecwqxsklZnxVCSJRdNT3C//dyLTl\nDCpETJmaz9BtM0uUPOGnbqKBFyn7Vh3LnDaloxG6KJI5GChUPwKYKZjUnTWq\nuzkOrzm+PB24i6GC2cXFahVtp4Zjradcw9jvGpTeGXYTXJ5hHAuEnBnoSN2s\n34IrsaGCfZm/uIi2L3UAQRNhEA0yp4uK07y8YJUFTrUKOAYZftrRCRYW+OPZ\nIr56AkNOOx17I/7xuIoXDJ4FHyozt6AJdy1jJTk3mTYq3VOLwRAKzaWc41ub\n8Uzbv4gThhgfIiAoXCQ5cBkQ\n",
-    "iv": "/f3Dx98vqXPA1sfRFY+W2w==\n",
+    "encrypted_data": "1iy6/MSqHP8pNme6z4SNqVJ6iP0HNT+/BiZOw5eitsbIyqBeNyMtPtTnKhae\n7i68zQWYvVqpB5AoEDeMGZq9qjS4wccAAmQdgWDbczUc/qADoYDwxNtUwLff\nBPkkrPpgE74iYgDdS3gM7BwE3Ri5z/ocq6MOiBXcyZJOCWp3q9SNw26S/e8W\nyNKTiKDl0Nt2cj+eJNUB3E/u4iGuvxblJCtdAZBg+k2WhRT20vKWpQT2hvCB\ncFsK10iHSKDvfUdD/CocVOvDeVWdkPOztuPZUDDqWKo26wdPGjiATO5sJ0LS\nFVLXtr/aryirSrOPW2FkdQWJtHS63FGkfUtUPR7UwqVmRN43xttB/nqL1+KZ\nCs3of5NUDWgf9sS8JSDn2P+2\n",
+    "iv": "oy6HsvGzWaC6sGOjlTnQDg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
+  },
+  "admin_password": {
+    "encrypted_data": "POaRTh7bYNTIvZmEuTmd7tg0bhvYsx11whPzu4eyjTs=\n",
+    "iv": "77gJalPcjVNsQTUbt0GtRg==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   }

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -17,6 +17,9 @@
         "alerts": "cerner_splunk/alerts-vagrant:alerts",
         "secrets": {
           "s_standalone": "cerner_splunk/standalone_passwords:splunk.secret"
+        },
+        "admin_password": {
+          "s_standalone": "cerner_splunk/standalone_passwords:admin_password"
         }
       },
       "data_bag_secret": "/vagrant/vagrant_repo/alternative_encrypted_data_bag_secret"


### PR DESCRIPTION
The cookbook has partial support for configuring the pass4SymmKey, but it was missing for certain node types.  This adds in support for setting it on cluster masters, cluster slaves and shc deployers.

In addition, previously there was no way to specify the admin password. It was always randomly generated and reset on every chef run.  This adds in the ability to set the admin password to a specific value via data bag.