### PR TITLE
Update Splunk to 7.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.1.6
 - 2.3.1
 script:
 - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -6,34 +6,12 @@ foodcritic_version = '= 11.0.0'
 rubocop_version = '= 0.48.1'
 chef_vault_version = '> 3.0'
 
-case RUBY_VERSION
-when '2.1.6'
-  # Version 5.0 introduced before_notifications matchers https://github.com/sethvargo/chefspec/pull/722
-  # This feature wasn't in Chef until Chef 12.6 https://github.com/chef/chef/pull/4062
-  chefspec_version = '< 5.0'
-  # Later versions require Ruby 2.2
-  foodcritic_version = '< 8.0'
-  # This is our target chef for this ruby version
-  # Omnibus Definition: https://github.com/chef/omnibus-chef/blob/chef-12.4.3/config/projects/chef.rb#L36
-  chef_version = '= 12.4.3'
-  # Later versions require Ruby 2.2
-  chef_vault_version = '< 3.0'
-  # Later versions require Ruby 2.2
-  gem 'fauxhai', '< 3.10'
-  # Later versions require Ruby 2.2
-  gem 'nio4r', '< 2.0'
-  # Later versions require Ruby 2.2
-  gem 'rack', '< 2.0'
-  # Later versions (and thus berkshelf) won't load on chef < 12.5
-  # See: https://github.com/berkshelf/ridley/issues/336
-  gem 'ridley', '< 4.4.2'
-else
-  # https://github.com/cerner/cerner_splunk/issues/142
-  chef_version = '= 12.18.31'
-end
+# https://github.com/cerner/cerner_splunk/issues/142
+chef_version = '= 12.18.31'
 
 gem 'berkshelf'
 gem 'chef', chef_version
+gem 'chef-sugar'
 gem 'chef-vault', chef_vault_version
 gem 'chefspec', chefspec_version
 gem 'foodcritic', foodcritic_version

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,8 +13,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '7.0.1'
-default['splunk']['package']['build'] = '2b5b15c4ee89'
+default['splunk']['package']['version'] = '7.0.3'
+default['splunk']['package']['build'] = 'fa31da744b51'
 
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`7.0.1`)
-* `node['splunk']['package']['build']` - Corresponding build number (`2b5b15c4ee89`)
+* `node['splunk']['package']['version']` - Major version to install (`7.0.3`)
+* `node['splunk']['package']['build']` - Corresponding build number (`fa31da744b51`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -38,7 +38,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-7.0.1-2b5b15c4ee89' }
+  let(:splunk_file) { 'splunkforwarder-7.0.3-fa31da744b51' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -53,7 +53,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.0.1-2b5b15c4ee89-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.0.3-fa31da744b51-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Why?
I am submitting this PR because Splunk 7.0.1 is having issues with indexer clusters and Charlie recommended that I upgrade to 7.0.3.