### PR TITLE
Minor cleanup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,7 +93,7 @@ Vagrant.configure('2') do |config|
   config.vm.define :chef do |cfg|
     config.omnibus.chef_version = nil
 
-    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk'
+    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk -v 2.5.3'
 
     if ENV['KNIFE_ONLY']
       cfg.vm.provision :shell, inline: 'cd /vagrant/vagrant_repo; mv nodes .nodes.bak', privileged: false

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -26,9 +26,6 @@ default['splunk']['main_project_index'] = nil
 default['splunk']['monitors'] = []
 default['splunk']['apps'] = {}
 
-# Flag attributes for warnings
-default['splunk']['flags']['index_checks_fail'] = true
-
 default['splunk']['config']['assumed_index'] = 'main'
 
 # Attribute used to point a heavy forwarder to license master


### PR DESCRIPTION
Vagrant provisioning is broken in master since it installs the latest chefdk with Chef 14 on it.  This cookbook hasn't been updated to be compatible yet, and the the chef node fails to provision.  Chefdk 2.5.3 is the last version that still works, even though it embeds Chef 13.

We missed removing the default index_checks_fail attribute in #154.