### PR TITLE
adding new attribute for  Search Head Cluster in cloud

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -15,7 +15,7 @@ default['splunk']['external_config_directory'] =
 
 default['splunk']['package']['version'] = '7.2.5.1'
 default['splunk']['package']['build'] = '962d9a8e1586'
-
+default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']
 default['splunk']['package']['file_suffix'] =

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,8 +13,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '7.2.5.1'
-default['splunk']['package']['build'] = '962d9a8e1586'
+default['splunk']['package']['version'] = '7.2.6'
+default['splunk']['package']['build'] = 'c0bf0f679ce9'
 default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,7 +18,7 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`7.2.5.1`)
+* `node['splunk']['package']['version']` - Major version to install (`7.2.6`)
 * `node['splunk']['package']['build']` - Corresponding build number (`962d9a8e1586`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -46,6 +46,7 @@ Configurable (with defaults)
 * `node['splunk']['mgmt_host']` - The host other SHC members use when connecting to the current node. You probably want a wrapper cookbook to override this. By default `node['splunk']['mgmt_interface']` is now used, but to support existing configurations this attribute is still available and takes precedence when set. (`nil`)
 * `node['splunk']['mgmt_interface']` - The network interface this node should use for communicating with other members of a SHC. (`node['network']['default_interface']`)
 * `node['splunk']['windows_password']` - This should be the name of a data bag item key where your windows password for the `Splunk` user is stored.
+* `node['splunk']['is_cloud']` - Set this attribute to `true` on cloud instances for Search Head Cluster (SHC). (`false`)
 
 Non-configurable (defaults)
 ----------------------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.27.0'
+version          '2.28.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/shc_deployer.rb
+++ b/recipes/shc_deployer.rb
@@ -9,7 +9,7 @@ fail 'Deployer installation not currently supported on windows' if platform_fami
 
 search_heads = CernerSplunk.my_cluster_data(node)['shc_members']
 
-fail 'Search Heads are not configured for sh clustering in the cluster databag' if search_heads.nil? || search_heads.empty?
+fail 'Search Heads are not configured for sh clustering in the cluster databag' if (search_heads.nil? || search_heads.empty?) && (node['splunk']['is_cloud'] == false)
 
 instance_exec :shc_deployer, &CernerSplunk::NODE_TYPE
 
@@ -20,6 +20,7 @@ execute 'apply-shcluster-bundle' do # ~FC009
   environment 'HOME' => node['splunk']['home']
   action :nothing
   sensitive true
+  not_if { node['splunk']['is_cloud'] }
 end
 
 cluster_data = CernerSplunk.my_cluster_data(node) || {}

--- a/recipes/shc_search_head.rb
+++ b/recipes/shc_search_head.rb
@@ -8,7 +8,7 @@
 fail 'Search Head installation not currently supported on windows' if platform_family?('windows')
 
 search_heads = CernerSplunk.my_cluster_data(node)['shc_members']
-fail 'Search Heads are not configured for sh clustering in the cluster databag' if search_heads.nil? || search_heads.empty?
+fail 'Search Heads are not configured for sh clustering in the cluster databag' if (search_heads.nil? || search_heads.empty?) && (node['splunk']['is_cloud'] == false)
 ## Attributes
 instance_exec :shc_search_head, &CernerSplunk::NODE_TYPE
 

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -40,7 +40,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-7.2.5.1-962d9a8e1586' }
+  let(:splunk_file) { 'splunkforwarder-7.2.6-c0bf0f679ce9' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -55,7 +55,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.2.5.1-962d9a8e1586-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.2.6-c0bf0f679ce9-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')

--- a/spec/unit/recipes/shc_deployer_spec.rb
+++ b/spec/unit/recipes/shc_deployer_spec.rb
@@ -59,7 +59,7 @@ describe 'cerner_splunk::shc_deployer' do
     CernerSplunk.reset
   end
 
-  context 'when the search heads are not specified for sh clustering in the cluster databag' do
+  context 'when the search heads are not specified for sh clustering in the cluster databag and is_cloud is false' do
     let(:cluster_config) do
       {
         'sh_cluster' => []
@@ -140,5 +140,11 @@ describe 'cerner_splunk::shc_deployer' do
 
   it 'includes cerner_splunk::_start recipe' do
     expect(subject).to include_recipe('cerner_splunk::_start')
+  end
+
+  context 'when is_cloud is true' do
+    it 'does not execute apply-shcluster-bundle' do
+      expect(subject).not_to run_execute('apply-shcluster-bundle')
+    end
   end
 end

--- a/spec/unit/recipes/shc_search_head_spec.rb
+++ b/spec/unit/recipes/shc_search_head_spec.rb
@@ -37,7 +37,7 @@ describe 'cerner_splunk::shc_search_head' do
     CernerSplunk.reset
   end
 
-  context 'when the search heads are not specified for sh clustering in the cluster databag' do
+  context 'when the search heads are not specified for sh clustering in the cluster databag and is_cloud is false' do
     let(:cluster_config) do
       {
         'sh_cluster' => []
@@ -61,7 +61,6 @@ describe 'cerner_splunk::shc_search_head' do
   it 'includes cerner_splunk::_start recipe' do
     expect(subject).to include_recipe('cerner_splunk::_start')
   end
-
   context 'when adding a new shc member to an existing cluster' do
     it 'executes add SH to SHC' do
       expect(subject).to add_sh_member('add SH to SHC')


### PR DESCRIPTION
>Updated new version of Splunk 7.2.6. 
>I have added the "is_cloud" attribute for Search head clustering as the shc_member IP's to be provided in data-bag for SHC are not available for cloud instances initially.  