### PR TITLE
adding attribute for boot start arguments

### DIFF
--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -36,4 +36,12 @@ default['splunk']['heavy_forwarder']['use_license_uri'] = false
 default['splunk']['forwarder_site'] = 'site0'
 
 # Give options to set splunk enable boot-start arguments
-default['splunk']['boot_start_args'] = ' -systemd-managed 0'
+default['splunk']['boot_start_args'] =
+  case node['platform_version'].to_i
+  when 6
+    ' -systemd-managed 0'
+  when 7
+    ' -systemd-managed 1'
+  else
+    ' -systemd-managed 0'
+  end

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -41,7 +41,10 @@ default['splunk']['boot_start_args'] =
   when 6
     ' -systemd-managed 0'
   when 7
-    ' -systemd-managed 1'
+    ' -systemd-managed 1 -systemd-unit-file-name splunk'
   else
     ' -systemd-managed 0'
   end
+
+# Default systemd file location based on default systemd unit file name
+default['splunk']['systemd_file_location'] = '/etc/systemd/system/multi-user.target.wants/splunk.service'

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -34,3 +34,6 @@ default['splunk']['heavy_forwarder']['use_license_uri'] = false
 
 # Disable site awareness for multisite clustering.
 default['splunk']['forwarder_site'] = 'site0'
+
+# Give options to set splunk enable boot-start arguments
+default['splunk']['boot_start_args'] = ' -systemd-managed 0'

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -37,11 +37,15 @@ default['splunk']['forwarder_site'] = 'site0'
 
 # Give options to set splunk enable boot-start arguments
 default['splunk']['boot_start_args'] =
-  case node['platform_version'].to_i
-  when 6
-    ' -systemd-managed 0'
-  when 7
-    ' -systemd-managed 1 -systemd-unit-file-name splunk'
+  if platform_family? 'rhel', 'fedora', 'amazon'
+    case node['platform_version'].to_i
+    when 6
+      ' -systemd-managed 0'
+    when 7
+      ' -systemd-managed 1 -systemd-unit-file-name splunk'
+    else
+      ' -systemd-managed 0'
+    end
   else
     ' -systemd-managed 0'
   end

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -47,6 +47,7 @@ Configurable (with defaults)
 * `node['splunk']['mgmt_interface']` - The network interface this node should use for communicating with other members of a SHC. (`node['network']['default_interface']`)
 * `node['splunk']['windows_password']` - This should be the name of a data bag item key where your windows password for the `Splunk` user is stored.
 * `node['splunk']['is_cloud']` - Set this attribute to `true` on cloud instances for Search Head Cluster (SHC). (`false`)
+* `node['splunk']['boot_start_args']` - Set splunk enabled boot-start arguments here. (` -systemd-managed 0`)
 
 Non-configurable (defaults)
 ----------------------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.28.0'
+version          '2.29.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -16,6 +16,7 @@ if Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7
 end
 execute command do
   not_if { platform_family?('windows') }
+  not_if { File.exist?(node['splunk']['systemd_file_location']) }
 end
 
 ruby_block 'insert ulimit' do
@@ -25,6 +26,7 @@ ruby_block 'insert ulimit' do
     file.write_file
   end
   not_if { platform_family?('windows') }
+  not_if { Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7.2.2') && node['platform_version'].to_i == 7 }
 end
 
 ruby_block 'restart-splunk-for-ulimit' do
@@ -38,6 +40,14 @@ end
 ruby_block 'start-splunk' do
   block { true }
   notifies :start, 'service[splunk]', :immediately
+end
+
+# Added in because the first time splunk is started using chef and systemd the .pid file is owned by root which causes issues. It is automatically correct when splunk is restarted.
+execute 'correct permissions' do
+  command "chown -RP #{node['splunk']['user']}:#{node['splunk']['group']} #{node['splunk']['home']}"
+  action :run
+  not_if { platform_family?('windows') }
+  only_if { Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7.2.2') && node['platform_version'].to_i == 7 }
 end
 
 include_recipe 'cerner_splunk::_generate_password'

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -12,7 +12,7 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 # We want to always ensure that the boot-start script is in place on non-windows platforms
 command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
 if Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7.2.2')
-  command += ' -systemd-managed 0'
+  command += node['splunk']['boot_start_args']
 end
 execute command do
   not_if { platform_family?('windows') }


### PR DESCRIPTION
I am creating an attribute so that we can configure more splunk enable boot-start arguments while still leaving what was there as the default attribute.