### PR TITLE
Update dependencies, fix lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,14 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
+  Exclude:
+    - 'Vagrantfile'
+    - 'Gemfile'
+    - 'Berksfile'
 
-BlockLength:
+Metrics/BlockLength:
   Enabled: false
 
-LineLength:
+Metrics/LineLength:
   Enabled: false
 
 EachWithObject:
@@ -13,7 +17,7 @@ EachWithObject:
 EmptyWhen:
   Enabled: false
 
-MethodLength:
+Metrics/MethodLength:
   Max: 40
 
 Metrics/AbcSize:
@@ -31,5 +35,5 @@ Style/NumericPredicate:
 Style/TernaryParentheses:
   Enabled: false
 
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ AllCops:
     - 'Vagrantfile'
     - 'Gemfile'
     - 'Berksfile'
+    - 'vendor/**/*'
+    - '.git/**/*'
 
 Metrics/BlockLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,16 @@
 source 'https://rubygems.org'
 
 # Going forward, these should be updated to the latest versions immediately post release
-chefspec_version = '= 7.0.0'
-foodcritic_version = '= 11.0.0'
-rubocop_version = '= 0.48.1'
+chefspec_version = '= 8.0.0'
+# Don't upgrade until https://github.com/Foodcritic/foodcritic/issues/760 is fixed
+foodcritic_version = '= 12.3.0'
+rubocop_version = '= 0.74.0'
 chef_vault_version = '> 3.0'
 
 chef_version = if Bundler.current_ruby.on_23?
                  '= 12.18.31'
                else
-                 '= 14.5.27'
+                 '= 14.13.11'
                end
 
 gem 'berkshelf'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
 # Going forward, these should be updated to the latest versions immediately post release
-chefspec_version = '= 8.0.0'
+chefspec_version = if Bundler.current_ruby.on_23?
+                 '= 7.3.4'
+               else
+                 '= 8.0.0'
+               end
 # Don't upgrade until https://github.com/Foodcritic/foodcritic/issues/760 is fixed
 foodcritic_version = '= 12.3.0'
 rubocop_version = '= 0.74.0'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Let's say I'm on the Awesome Team, and I am setting up an Apache server, and wan
 4. I make changes to my chef artifacts:
     * I alter the environment for my nodes:
      ```ruby
-     # coding: UTF-8
+     # frozen_string_literal: true
 
      name 'awesomeness_corporate'
      description 'Node Environment for the Awesome Team Servers in Corporate'
@@ -64,7 +64,7 @@ Let's say I'm on the Awesome Team, and I am setting up an Apache server, and wan
      ```
     * I create a role:
      ```ruby
-      # coding: UTF-8
+      # frozen_string_literal: true
 
       name 'awesomeness_ops'
       description 'Awesome Operations Role'

--- a/Thorfile
+++ b/Thorfile
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 require 'bundler'
 require 'bundler/setup'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,7 +92,7 @@ Vagrant.configure('2') do |config|
   config.vm.define :chef do |cfg|
     config.omnibus.chef_version = nil
 
-    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk -v 2.5.3'
+    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk -v 4.0.60'
 
     if ENV['KNIFE_ONLY']
       cfg.vm.provision :shell, inline: 'cd /vagrant/vagrant_repo; mv nodes .nodes.bak', privileged: false

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 default['splunk']['config']['host'] = node['ec2'] ? node['ec2']['instance_id'] : (node['fqdn'] || node['machinename'] || node['hostname'])
 

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Put this here to initialize the run state so we don't have to check it everywhere
 node.run_state['cerner_splunk'] ||= {} # ~FC046

--- a/attributes/_user_management.rb
+++ b/attributes/_user_management.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Do not override these
 if node['platform_family'] == 'windows'

--- a/libraries/alerts.rb
+++ b/libraries/alerts.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: alerts.rb
@@ -29,6 +29,7 @@ module CernerSplunk
       if email_settings['auth_password']
         password = CernerSplunk::DataBag.load email_settings['auth_password'], default: default_coords, secret: node['splunk']['data_bag_secret']
         fail 'Password must be a String' unless password.is_a?(String)
+
         email_settings['auth_password'] = password
       end
       alert_stanzas

--- a/libraries/authentication.rb
+++ b/libraries/authentication.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: authentication.rb
@@ -41,7 +41,7 @@ module CernerSplunk
       end
 
       ASSUMPTIONS.each do |key, type|
-        if hash['authType'] != type && hash.key?(key)
+        if hash['authType'] != type && hash.key?(key) # rubocop:disable Style/IfUnlessModifier
           fail "#{key} is only supported with #{type}. authType = #{hash['authType']}"
         end
       end
@@ -56,6 +56,7 @@ module CernerSplunk
           'scriptPath' => hash.delete('scriptPath')
         }
         fail 'scriptPath required for Scripted authentication' unless script['scriptPath']
+
         search_filters = hash.delete('scriptSearchFilters')
         script['scriptSearchFilters'] = search_filters if search_filters
         hash['authSettings'] = 'script'
@@ -63,11 +64,13 @@ module CernerSplunk
         cache_timing = hash.delete('cacheTiming')
         if cache_timing
           fail "Unknown type for cacheTiming: #{cacheTiming.class}" unless cache_timing.is_a?(Hash)
+
           auth_stanzas['cacheTiming'] = cache_timing
         end
       when 'LDAP'
         strategies = hash.delete('LDAP_strategies')
         fail 'LDAP_strategies required for LDAP authentication' unless strategies
+
         strategies = [strategies] unless strategies.is_a? Array
         strategies = strategies.collect do |strategy|
           hash =
@@ -126,6 +129,7 @@ module CernerSplunk
           auth_stanzas["roleMap_#{strategy_name}"] = strategy.delete('roleMap')
 
           fail "Resolved Role Map for Strategy Name #{strategy_name} is empty!!!" if auth_stanzas["roleMap_#{strategy_name}"].empty?
+
           strategy_name
         end.join(',')
       else

--- a/libraries/conf.rb
+++ b/libraries/conf.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: conf.rb
@@ -6,12 +6,13 @@
 module CernerSplunk
   # Utilities for working with splunk configuration files
   module Conf
-    STANZA_START ||= /^\s*\[(?<stanza_name>[^\]]+)\].*$/
-    COMMENT_LINE ||= /^\s*#.*$/
-    KEY_VALUE_PAIR ||= /^(?<key>[^=]+)=(?<value>.*)$/
+    STANZA_START ||= /^\s*\[(?<stanza_name>[^\]]+)\].*$/.freeze
+    COMMENT_LINE ||= /^\s*#.*$/.freeze
+    KEY_VALUE_PAIR ||= /^(?<key>[^=]+)=(?<value>.*)$/.freeze
 
     def self.parse_string(conf)
       return {} if conf.nil?
+
       parse StringIO.open(conf, 'r:UTF-8')
     end
 
@@ -45,10 +46,11 @@ module CernerSplunk
 
       def read
         return {} unless File.exist?(@filename)
+
         file = File.open(@filename, 'r:UTF-8')
         CernerSplunk::Conf.parse file
       ensure
-        file.close if file
+        file&.close
       end
     end
   end

--- a/libraries/conf_template.rb
+++ b/libraries/conf_template.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: conf_template.rb
@@ -12,6 +12,7 @@ module CernerSplunk
         message_suffix = " evaluating #{label}" unless label.nil?
         while value.is_a? Proc
           fail "Proc depth exceeded#{message_suffix}" if depth <= 0
+
           value = value.call(arguments)
           depth -= 1
         end
@@ -24,6 +25,7 @@ module CernerSplunk
           label = "Stanza #{stanza}"
           stanza_value = CernerSplunk::ConfTemplate.collapse_proc stanza_value, label: label, arguments: { stanza: stanza }
           fail "Unexpected value (#{stanza_value.class} '#{stanza_value}') for #{label}" unless stanza_value.nil? || stanza_value.is_a?(Hash)
+
           if stanza_value.is_a? Hash
             file_data[stanza] = stanza_value.inject({}) do |result, (attribute, value)|
               label = "Attribute #{attribute}, Stanza #{stanza}"
@@ -37,7 +39,7 @@ module CernerSplunk
       end
 
       # Compose two procs... I should monkey patch this in, but changing core ruby just seems wrong
-      def self.compose(g, f)
+      def self.compose(g, f) # rubocop:disable Naming/UncommunicativeMethodParamName
         proc { |*a| g[*f[*a]] }
       end
 
@@ -47,7 +49,7 @@ module CernerSplunk
           @reader = CernerSplunk::Conf::Reader.new filename
         end
 
-        def [](x)
+        def [](x) # rubocop:disable Naming/UncommunicativeMethodParamName
           data[x]
         end
 

--- a/libraries/databag.rb
+++ b/libraries/databag.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: databag.rb
@@ -59,6 +59,7 @@ module CernerSplunk #:nodoc:
         nil
       when Array
         fail "Array '#{array}' can only contain Strings or nil" unless array.all? { |i| i.nil? || i.is_a?(String) }
+
         data_bag, bag_item, key = array
         Chef::DataBag.validate_name!(data_bag) if data_bag
         Chef::DataBagItem.validate_id!(bag_item) if bag_item
@@ -95,8 +96,9 @@ module CernerSplunk #:nodoc:
                     ChefVault::Item.load(data_bag, bag_item)
                   end
             key ? bag[key] : bag
-          rescue => e
+          rescue => e # rubocop:disable Style/RescueStandardError
             raise e unless opts[:handle_load_failure]
+
             Chef::Log.warn "Could not load the data bag item referenced by: #{to_value([data_bag, bag_item])}. Details available at debug log level, continuing chef run assuming nil."
             Chef::Log.debug "#{e.class}: #{e}\n#{e.backtrace.join("\n")}" if Chef::Log.level == :debug
             nil
@@ -117,7 +119,7 @@ module CernerSplunk #:nodoc:
         string.strip! if strip
         string = nil if string.empty? && default_empty
       end
-      string ? string : default
+      string || default
     end
 
     # Finds a particular value in a hash by key, Not part of the public API
@@ -125,9 +127,8 @@ module CernerSplunk #:nodoc:
       attempts = [key]
       value = data_bag_item[key]
       while value.is_a? String
-        if attempts.include? value
-          fail "Circular reference resolving key (#{attempts.join(';')})!"
-        end
+        fail "Circular reference resolving key (#{attempts.join(';')})!" if attempts.include? value
+
         attempts << value
         value = data_bag_item[value]
       end

--- a/libraries/lwrp.rb
+++ b/libraries/lwrp.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: lwrp.rb
@@ -40,7 +40,7 @@ module CernerSplunk
     # Extension of the Resource DSL, defines an attribute that can be set upfront or can be calculated at convergence time.
     module DelayableAttribute
       def delayable_attribute(attr_name, validation = {}) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
-        class_eval(<<-SHIM, __FILE__, __LINE__)
+        class_eval(<<-SHIM, __FILE__, __LINE__ + 1)
           def #{attr_name}(arg=nil,&block)
             _set_or_return_#{attr_name}(arg,block)
           end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(ChefSpec)
   ChefSpec.define_matcher :splunk_app
   ChefSpec.define_matcher :splunk_template

--- a/libraries/outputs.rb
+++ b/libraries/outputs.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: outputs.rb

--- a/libraries/passive_sensitive.rb
+++ b/libraries/passive_sensitive.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: passive_sensitive.rb

--- a/libraries/rc4.rb
+++ b/libraries/rc4.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: rc4.rb

--- a/libraries/recipe.rb
+++ b/libraries/recipe.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: recipe.rb
@@ -34,6 +34,7 @@ module CernerSplunk
   def self.my_cluster_data(node)
     @my_cluster_data ||= CernerSplunk::DataBag.load(node['splunk']['config']['clusters'].first, secret: node['splunk']['data_bag_secret'])
     return @my_cluster_data if @my_cluster_data.nil?
+
     @multisite_bag_data ||= CernerSplunk::DataBag.load(@my_cluster_data['multisite'], secret: node['splunk']['data_bag_secret']) || {}
     CernerSplunk::SplunkApp.merge_hashes({ cluster_configs: @multisite_bag_data.to_h }, { cluster_configs: @my_cluster_data.to_h })[:cluster_configs]
   end
@@ -102,6 +103,7 @@ module CernerSplunk
 
     # Windows package names
     return 'Splunk Enterprise' if package_base_name == 'splunk'
+
     'UniversalForwarder'
   end
 
@@ -125,6 +127,7 @@ module CernerSplunk
   # Fails the chef run if those constraints are not met.
   def self.validate_secret_file(secret_file_path, configured_secret)
     return unless ::File.exist?(secret_file_path)
+
     existing_secret = ::File.open(secret_file_path, 'r') { |file| file.readline.chomp }
     fail 'The splunk.secret file already exists with a different value. Modification of that file is not currently supported.' if existing_secret != configured_secret
   end
@@ -133,6 +136,7 @@ module CernerSplunk
   def self.multisite_cluster?(bag, cluster)
     return false if bag['multisite'].nil? || bag['multisite'].empty?
     fail "'site' attribute not configured in the cluster databag: #{cluster}" if bag['site'].nil? || bag['site'].empty?
+
     true
   end
 

--- a/libraries/roles.rb
+++ b/libraries/roles.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: roles.rb
@@ -25,7 +25,7 @@ module CernerSplunk
           when 'capabilities'
             value.each do |cap|
               if cap.start_with? '!'
-                cap[0] = ''
+                cap = cap[1..-1]
                 auth[cap] = 'disabled'
               else
                 auth[cap] = 'enabled'

--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: splunk_password.rb

--- a/libraries/splunk_template.rb
+++ b/libraries/splunk_template.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: splunk_template.rb
@@ -76,6 +76,7 @@ class Chef
 
         config_file = ::File.basename(@path)
         return if KNOWN_CONFIG_FILES.include? config_file
+
         message = "#{config_file} is not known to this resource. Check spelling or submit a pull request."
         Chef::Log.warn message unless fail_unknown
         fail Exceptions::ValidationFailed, "#{message}\nKnown files are:\n\t#{KNOWN_CONFIG_FILES.join("\n\t")}" if fail_unknown

--- a/libraries/tarball.rb
+++ b/libraries/tarball.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: tarball.rb
@@ -46,6 +46,7 @@ module CernerSplunk
       target_path = @prefix.nil? ? name : "#{@prefix}/#{name}"
       iterate file: proc { |path, entry| data << entry.read if path == target_path }, other: proc {}
       fail "Multiple entries for #{target_path} found in #{@file_name}" if data.size > 1
+
       data.first
     end
 
@@ -132,8 +133,8 @@ module CernerSplunk
         when 'K' # LongSymLink
           long_link = entry.read.strip
         else
-          path = long_path && long_path.start_with?(entry.full_name) ? long_path : entry.full_name
-          linkname = long_link && long_link.start_with?(entry.header.linkname) ? long_link : entry.header.linkname
+          path = long_path&.start_with?(entry.full_name) ? long_path : entry.full_name
+          linkname = long_link&.start_with?(entry.header.linkname) ? long_link : entry.header.linkname
 
           # Determine which callback to invoke based on the typeflag
           callback = callbacks[:file] if entry.header.typeflag == '0'
@@ -173,7 +174,8 @@ module CernerSplunk
 
       def call(*)
         return if @pid != $PID
-        @data.drop(1).reverse_each { |io| io.close if io }
+
+        @data.drop(1).reverse_each { |io| io&.close }
       end
     end
   end

--- a/libraries/unit_converter.rb
+++ b/libraries/unit_converter.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # File Name:: unit_converter.rb
@@ -7,7 +7,7 @@
 #
 module CernerSplunk
   SIZE_SCALE ||= %w[KB MB GB TB].freeze
-  REGEX ||= /(?i)^\s*+(\d++(?>\.\d+)?+)\s*+([kmgt](?>i?+b)?+|b?+)\s*+$/
+  REGEX ||= /(?i)^\s*+(\d++(?>\.\d+)?+)\s*+([kmgt](?>i?+b)?+|b?+)\s*+$/.freeze
   POWER ||= { '' => 0, 'B' => 0, 'K' => 1, 'M' => 2, 'G' => 3, 'T' => 4 }.freeze
   # Methods converts file sizes in KB, MB, GB and TB into Bytes.
   def self.convert_to_bytes(string)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 name             'cerner_splunk'
 maintainer       'Healthe Intent Infrastructure - Cerner Innovation, Inc.'
 maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.30.0'
+version          '2.30.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/providers/forwarder_monitors.rb
+++ b/providers/forwarder_monitors.rb
@@ -1,11 +1,9 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Provider:: forwarder_monitors
 #
 # Drop in replacement for the existing splunk_forwarder_monitors
-
-use_inline_resources
 
 provides :splunk_forwarder_monitors if respond_to?(:provides)
 provides :cerner_splunk_forwarder_monitors if respond_to?(:provides)

--- a/providers/sh_cluster.rb
+++ b/providers/sh_cluster.rb
@@ -1,10 +1,8 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Provider:: sh_cluster
 #
-
-use_inline_resources
 
 action :initialize do
   search_heads = new_resource.search_heads

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure
@@ -16,7 +16,7 @@ unless node.run_state['cerner_splunk']['configure_apps_only']
   end
 
   node['splunk']['config']['clusters'].each do |cluster|
-    unless CernerSplunk::DataBag.load(cluster, secret: node['splunk']['data_bag_secret'])
+    unless CernerSplunk::DataBag.load(cluster, secret: node['splunk']['data_bag_secret']) # rubocop:disable Style/IfUnlessModifier
       throw "Unknown databag configured for node['splunk']['config]['clusters'] => '#{cluster}'"
     end
   end

--- a/recipes/_configure_alerts.rb
+++ b/recipes/_configure_alerts.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_alerts

--- a/recipes/_configure_apps.rb
+++ b/recipes/_configure_apps.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_apps

--- a/recipes/_configure_authentication.rb
+++ b/recipes/_configure_authentication.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_authentication

--- a/recipes/_configure_indexes.rb
+++ b/recipes/_configure_indexes.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_indexes
@@ -74,9 +74,7 @@ index_stanzas = config.inject({}) do |result, (stanza, index_config)|
   result
 end
 
-if is_master && index_stanzas['_introspection'].nil?
-  index_stanzas['_introspection'] = { 'repFactor' => 'auto' }
-end
+index_stanzas['_introspection'] = { 'repFactor' => 'auto' } if is_master && index_stanzas['_introspection'].nil?
 
 path = is_master ? 'master-apps/_cluster/indexes.conf' : 'system/indexes.conf'
 

--- a/recipes/_configure_inputs.rb
+++ b/recipes/_configure_inputs.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_inputs

--- a/recipes/_configure_logs.rb
+++ b/recipes/_configure_logs.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_logs

--- a/recipes/_configure_outputs.rb
+++ b/recipes/_configure_outputs.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_outputs

--- a/recipes/_configure_roles.rb
+++ b/recipes/_configure_roles.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_roles

--- a/recipes/_configure_secret.rb
+++ b/recipes/_configure_secret.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_secret

--- a/recipes/_configure_server.rb
+++ b/recipes/_configure_server.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_server
@@ -93,6 +93,7 @@ when :cluster_master
     server_stanzas['general']['site'] = bag['site']
     multisite_configs = CernerSplunk::DataBag.load(bag['multisite'], secret: node['splunk']['data_bag_secret']) || {}
     fail "sites attribute not configured in the multisite cluster databag: #{bag['multisite']}" if multisite_configs['sites'].nil? || multisite_configs['sites'].empty?
+
     available_sites = multisite_configs['sites'].map { |site| CernerSplunk::DataBag.load(site, secret: node['splunk']['data_bag_secret'])['site'] }
     settings = (multisite_configs['multisite_settings'] || {}).reject do |k, _|
       k.start_with?('_cerner_splunk')

--- a/recipes/_configure_shc_alerts.rb
+++ b/recipes/_configure_shc_alerts.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_shc_alerts

--- a/recipes/_configure_shc_authentication.rb
+++ b/recipes/_configure_shc_authentication.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_shc_authentication

--- a/recipes/_configure_shc_outputs.rb
+++ b/recipes/_configure_shc_outputs.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_shc_outputs

--- a/recipes/_configure_shc_roles.rb
+++ b/recipes/_configure_shc_roles.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_shc_roles

--- a/recipes/_configure_ui.rb
+++ b/recipes/_configure_ui.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _configure_ui

--- a/recipes/_generate_password.rb
+++ b/recipes/_generate_password.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _generate_password

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _install
@@ -84,9 +84,8 @@ include_recipe 'cerner_splunk::_configure_secret'
 windows_password = CernerSplunk::DataBag.load(node['splunk']['windows_password'], secret: node['splunk']['data_bag_secret'])
 
 run_command = "#{node['splunk']['cmd']} help commands --accept-license --answer-yes --no-prompt"
-if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.2.0')
-  run_command += " --seed-passwd 'changeme'"
-end
+run_command += " --seed-passwd 'changeme'" if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.2.0')
+
 # TODO: Use admin_password from databag for splunk-first-run.
 execute 'splunk-first-run' do
   command run_command

--- a/recipes/_install_server.rb
+++ b/recipes/_install_server.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _install_server

--- a/recipes/_migrate_forwarder.rb
+++ b/recipes/_migrate_forwarder.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _migrate_forwarder

--- a/recipes/_restart_marker.rb
+++ b/recipes/_restart_marker.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _restart_marker

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _start
@@ -11,9 +11,8 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 
 # We want to always ensure that the boot-start script is in place on non-windows platforms
 command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
-if Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7.2.2')
-  command += node['splunk']['boot_start_args']
-end
+command += node['splunk']['boot_start_args'] if Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7.2.2')
+
 execute command do
   not_if { platform_family?('windows') }
   not_if { File.exist?(node['splunk']['systemd_file_location']) }

--- a/recipes/_user_management.rb
+++ b/recipes/_user_management.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: _user_management

--- a/recipes/cluster_master.rb
+++ b/recipes/cluster_master.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: cluster_master

--- a/recipes/cluster_slave.rb
+++ b/recipes/cluster_slave.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: cluster_slave

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: default

--- a/recipes/forwarder.rb
+++ b/recipes/forwarder.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: forwarder

--- a/recipes/heavy_forwarder.rb
+++ b/recipes/heavy_forwarder.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: heavy_forwarder

--- a/recipes/image_prep.rb
+++ b/recipes/image_prep.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: image_prep

--- a/recipes/search_head.rb
+++ b/recipes/search_head.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: search_head

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: server

--- a/recipes/server_install_only.rb
+++ b/recipes/server_install_only.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Cookbook Name:: cerner_splunk
 # Recipe:: server_install_only
 #

--- a/recipes/shc_captain.rb
+++ b/recipes/shc_captain.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: shc_captain

--- a/recipes/shc_deployer.rb
+++ b/recipes/shc_deployer.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: shc_deployer

--- a/recipes/shc_remove_search_head.rb
+++ b/recipes/shc_remove_search_head.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: shc_remove_search_head

--- a/recipes/shc_search_head.rb
+++ b/recipes/shc_search_head.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Recipe:: shc_search_head
@@ -9,6 +9,7 @@ fail 'Search Head installation not currently supported on windows' if platform_f
 
 search_heads = CernerSplunk.my_cluster_data(node)['shc_members']
 fail 'Search Heads are not configured for sh clustering in the cluster databag' if (search_heads.nil? || search_heads.empty?) && (node['splunk']['is_cloud'] == false)
+
 ## Attributes
 instance_exec :shc_search_head, &CernerSplunk::NODE_TYPE
 

--- a/resources/forwarder_monitors.rb
+++ b/resources/forwarder_monitors.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
 # Resource:: forwarder_monitors

--- a/resources/sh_cluster.rb
+++ b/resources/sh_cluster.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: odw_cron
 # Resource:: sh_cluster

--- a/spec/cookbooks/cerner_splunk_test/attributes/default.rb
+++ b/spec/cookbooks/cerner_splunk_test/attributes/default.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 default[:splunk][:groups] = ['vagrant']

--- a/spec/cookbooks/cerner_splunk_test/metadata.rb
+++ b/spec/cookbooks/cerner_splunk_test/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 name             'cerner_splunk_test'
 maintainer       'Operations Infrastructure Team - Cerner Innovation, Inc.'
 maintainer_email 'DL_Population_Health_IP_OpsInfra@cerner.com'

--- a/spec/cookbooks/cerner_splunk_test/providers/lwrp.rb
+++ b/spec/cookbooks/cerner_splunk_test/providers/lwrp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 use_inline_resources
 
 action :go do

--- a/spec/cookbooks/cerner_splunk_test/recipes/configure_guids.rb
+++ b/spec/cookbooks/cerner_splunk_test/recipes/configure_guids.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk_test
 # Recipe:: configure_guids

--- a/spec/cookbooks/cerner_splunk_test/recipes/default.rb
+++ b/spec/cookbooks/cerner_splunk_test/recipes/default.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk_test
 # Recipe:: default

--- a/spec/cookbooks/cerner_splunk_test/resources/lwrp.rb
+++ b/spec/cookbooks/cerner_splunk_test/resources/lwrp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 default_action :go
 
 attribute :app,      kind_of: String, name_attribute: true, regex: [/^[A-Za-z0-9_-]/]

--- a/spec/unit/libraries/recipe_spec.rb
+++ b/spec/unit/libraries/recipe_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 require 'recipe'

--- a/spec/unit/libraries/splunk_app_spec.rb
+++ b/spec/unit/libraries/splunk_app_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 require 'splunk_app'

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 require 'splunk_password'

--- a/spec/unit/libraries/unit_converter_spec.rb
+++ b/spec/unit/libraries/unit_converter_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 require 'unit_converter'

--- a/spec/unit/recipes/_configure_apps_spec.rb
+++ b/spec/unit/recipes/_configure_apps_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_apps' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['apps'] = apps
     end
     runner.converge('cerner_splunk::_restart_marker', described_recipe)

--- a/spec/unit/recipes/_configure_indexes_spec.rb
+++ b/spec/unit/recipes/_configure_indexes_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_indexes' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
     end
     # Have to include marker recipe so that we can send notifications to its resources

--- a/spec/unit/recipes/_configure_logs_spec.rb
+++ b/spec/unit/recipes/_configure_logs_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_logs' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['logs'] = logs
     end
     runner.converge('cerner_splunk::_restart_marker', described_recipe)

--- a/spec/unit/recipes/_configure_outputs_spec.rb
+++ b/spec/unit/recipes/_configure_outputs_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
@@ -19,7 +19,7 @@ end
 
 describe 'cerner_splunk::_configure_outputs' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster', 'cerner_splunk/indexer_discovery_configs']
       node.override['splunk']['node_type'] = node_type
     end

--- a/spec/unit/recipes/_configure_secret_spec.rb
+++ b/spec/unit/recipes/_configure_secret_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 

--- a/spec/unit/recipes/_configure_server_spec.rb
+++ b/spec/unit/recipes/_configure_server_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_server' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = clusters
       node.override['splunk']['config']['host'] = node_type.to_s
       node.override['splunk']['node_type'] = node_type
@@ -64,7 +64,7 @@ describe 'cerner_splunk::_configure_server' do
   let(:multisite_bag_configs) do
     {
       'sites' => ['cerner_splunk/multisite_cluster'],
-      'multisite_settings' =>   {
+      'multisite_settings' => {
         'forwarder_site_failover' => 'site1:site2',
         'site_replication_factor' => 'origin:2,total:3',
         'site_search_factor' => 'origin:1,total:2'

--- a/spec/unit/recipes/_configure_shc_alerts_spec.rb
+++ b/spec/unit/recipes/_configure_shc_alerts_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_shc_alerts' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
       node.override['splunk']['config']['alerts'] = 'cerner_splunk/alerts'
     end

--- a/spec/unit/recipes/_configure_shc_authentication_spec.rb
+++ b/spec/unit/recipes/_configure_shc_authentication_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_shc_authentication' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
       node.override['splunk']['config']['authentication'] = 'cerner_splunk/authentication'
     end

--- a/spec/unit/recipes/_configure_shc_outputs_spec.rb
+++ b/spec/unit/recipes/_configure_shc_outputs_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_shc_outputs' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
     end
     runner.converge('cerner_splunk::shc_deployer', described_recipe)

--- a/spec/unit/recipes/_configure_shc_roles_spec.rb
+++ b/spec/unit/recipes/_configure_shc_roles_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure_shc_roles' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
       node.override['splunk']['config']['roles'] = 'cerner_splunk/roles'
     end

--- a/spec/unit/recipes/_configure_spec.rb
+++ b/spec/unit/recipes/_configure_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_configure' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = clusters
       node.override['splunk']['node_type'] = node_type
     end

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
@@ -31,7 +31,7 @@ describe 'cerner_splunk::_install' do
   let(:password_databag) { nil }
 
   let(:platform) { 'centos' }
-  let(:platform_version) { '6.8' }
+  let(:platform_version) { '6.10' }
 
   let(:initd_exists) { nil }
   let(:ui_login_exists) { nil }

--- a/spec/unit/recipes/_migrate_forwarder_spec.rb
+++ b/spec/unit/recipes/_migrate_forwarder_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
@@ -11,7 +11,7 @@ describe 'cerner_splunk::_migrate_forwarder' do
   end
 
   let(:platform) { 'centos' }
-  let(:platform_version) { '6.8' }
+  let(:platform_version) { '6.10' }
 
   it 'stops splunk service' do
     expect(subject).to stop_service('splunk').with(service_name: 'splunk')

--- a/spec/unit/recipes/_restart_marker_spec.rb
+++ b/spec/unit/recipes/_restart_marker_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::_restart_marker' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8')
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10')
     runner.converge(described_recipe)
   end
 

--- a/spec/unit/recipes/_start_spec.rb
+++ b/spec/unit/recipes/_start_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
@@ -29,7 +29,7 @@ describe 'cerner_splunk::_start' do
   let(:password_databag) { nil }
 
   let(:platform) { 'centos' }
-  let(:platform_version) { '6.8' }
+  let(:platform_version) { '6.10' }
 
   let(:lines) { [] }
   let(:exists) { nil }
@@ -81,8 +81,6 @@ describe 'cerner_splunk::_start' do
   end
 
   context 'when platform is not windows' do
-    let(:platform) { 'centos' }
-    let(:platform_version) { '6.9' }
     let(:windows) { false }
 
     it 'executes boot-start script' do

--- a/spec/unit/recipes/forwarder_spec.rb
+++ b/spec/unit/recipes/forwarder_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::forwarder' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
     end
     runner.converge(described_recipe)

--- a/spec/unit/recipes/heavy_forwarder_spec.rb
+++ b/spec/unit/recipes/heavy_forwarder_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::heavy_forwarder' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
       node.run_state['cerner_splunk'] = {}
       node.run_state['cerner_splunk']['splunk_forwarder_migrate'] = splunk_installed

--- a/spec/unit/recipes/server_install_only_spec.rb
+++ b/spec/unit/recipes/server_install_only_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::server_install_only' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8')
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10')
     runner.converge(described_recipe)
   end
 

--- a/spec/unit/recipes/shc_captain_spec.rb
+++ b/spec/unit/recipes/shc_captain_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::shc_captain' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
     end
     runner.converge(described_recipe)
@@ -60,6 +60,6 @@ describe 'cerner_splunk::shc_captain' do
   end
 
   it 'assigns the captain' do
-    expect(subject).to initialize_sh_cluster('Captain assignment')
+    expect(subject).to initialize_cerner_splunk_sh_cluster('Captain assignment')
   end
 end

--- a/spec/unit/recipes/shc_deployer_spec.rb
+++ b/spec/unit/recipes/shc_deployer_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::shc_deployer' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
     end
     runner.converge(described_recipe)

--- a/spec/unit/recipes/shc_remove_search_head_spec.rb
+++ b/spec/unit/recipes/shc_remove_search_head_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::shc_remove_search_head' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
     end
     runner.converge(described_recipe)

--- a/spec/unit/recipes/shc_search_head_spec.rb
+++ b/spec/unit/recipes/shc_search_head_spec.rb
@@ -1,10 +1,10 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
 describe 'cerner_splunk::shc_search_head' do
   subject do
-    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.10') do |node|
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
       node.override['splunk']['bootstrap_shc_member'] = bootstrap_shc_member
     end

--- a/spec/unit/resources/sh_cluster.rb
+++ b/spec/unit/resources/sh_cluster.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', 'libraries'))
 require 'rspec'

--- a/vagrant_repo/.chef/knife.rb
+++ b/vagrant_repo/.chef/knife.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# frozen_string_literal: true
 
 alternate_node = ENV['node']
 


### PR DESCRIPTION
We haven't done this for a while, so I updated to the latest foodcritic, rubocop, chef and chefdk versions and addressed all the new lint findings. For chef, I just moved to the latest in the 14.x line.  I figured bumping to Chef 15 should be a separate PR to address any changes there.