### PR TITLE
Update boot start scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: false
 rvm:
 - 2.3.1
 - 2.5.1
+addons:
+  apt:
+    packages:
+      - libarchive-dev
 script:
 - bundle exec rubocop
 - bundle exec foodcritic -f any .

--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,4 @@ gem 'chefspec', chefspec_version
 gem 'cucumber-core', '~> 3.2'
 gem 'foodcritic', foodcritic_version
 gem 'rubocop', rubocop_version
+gem 'ffi-libarchive'

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -52,4 +52,4 @@ default['splunk']['boot_start_args'] =
   end
 
 # Default systemd file location based on default systemd unit file name
-default['splunk']['systemd_file_location'] = '/etc/systemd/system/multi-user.target.wants/splunk.service'
+default['splunk']['systemd_file_location'] = '/etc/systemd/system/splunk.service'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.30.1'
+version          '2.31.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
@@ -15,6 +15,7 @@ chef_version     '>= 12.7', '< 15'
 
 depends          'chef-vault', '~> 3.0'
 depends          'ulimit', '~> 1.0'
+depends          'line', '~> 2.0'
 
 supports         'redhat', '>= 6.7'
 supports         'ubuntu', '>= 12.04'

--- a/spec/unit/recipes/_configure_shc_alerts_spec.rb
+++ b/spec/unit/recipes/_configure_shc_alerts_spec.rb
@@ -34,14 +34,13 @@ describe 'cerner_splunk::_configure_shc_alerts' do
       'shcluster' => {
         'bag' => ':base',
         'email' => {
-          'reportServerEnabled' => false
+          'from' => 'splunk@test.com'
         }
       },
       'base' => {
         'email' => {
           'mailserver' => 'smtprr.example.com',
-          'from' => 'splunk@example.com',
-          'reportServerEnabled' => true
+          'from' => 'splunk@example.com'
         }
       }
     }
@@ -64,8 +63,7 @@ describe 'cerner_splunk::_configure_shc_alerts' do
       stanzas: {
         'email' => {
           'mailserver' => 'smtprr.example.com',
-          'from' => 'splunk@example.com',
-          'reportServerEnabled' => false
+          'from' => 'splunk@test.com'
         }
       }
     }

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -112,7 +112,7 @@ describe 'cerner_splunk::_install' do
       it 'installs downloaded splunk package' do
         expected_attrs = {
           source: splunk_filepath,
-          options: %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="test\\splunkforwarder")
+          options: %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="test\\splunkforwarder" SPLUNKPASSWORD=changeme)
         }
         expect(subject).to install_windows_package('splunkforwarder').with(expected_attrs)
       end

--- a/vagrant_repo/data_bags/cerner_splunk/alerts-vagrant.json
+++ b/vagrant_repo/data_bags/cerner_splunk/alerts-vagrant.json
@@ -16,7 +16,6 @@
     "search_head": {
       "bag": ":base",
       "email": {
-        "reportServerEnabled":false
       }
     },
     "shcluster": "search_head"
@@ -25,7 +24,6 @@
     "email": {
       "mailserver": "smtprr.cerner.com",
       "from": "splunk-dev@cerner.com",
-      "reportServerEnabled":true,
       "subject": "Vagrant Splunk Alert: $name$",
       "inline":1
     }


### PR DESCRIPTION
Updated to follow the latest documentation:
* https://docs.splunk.com/Documentation/Splunk/latest/Admin/ConfigureSplunktostartatboottime#Enable_boot-start_as_a_non-root_user
* https://docs.splunk.com/Documentation/Splunk/7.3.1/Admin/RunSplunkassystemdservice#Configure_systemd_using_enable_boot-start

While I was testing, I ran into a number of other largely unrelated issues with the vagrant setup running under systemd.  Also, the windows install has been completely broken for some time, so I fixed that too.