### PR TITLE
Update Splunk to 7.3.1

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,8 +13,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '7.2.6'
-default['splunk']['package']['build'] = 'c0bf0f679ce9'
+default['splunk']['package']['version'] = '7.3.1'
+default['splunk']['package']['build'] = 'bd63e13aa157'
 default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`7.2.6`)
-* `node['splunk']['package']['build']` - Corresponding build number (`962d9a8e1586`)
+* `node['splunk']['package']['version']` - Major version to install (`7.3.1`)
+* `node['splunk']['package']['build']` - Corresponding build number (`bd63e13aa157`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.31.0'
+version          '2.32.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -40,7 +40,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-7.2.6-c0bf0f679ce9' }
+  let(:splunk_file) { 'splunkforwarder-7.3.1-bd63e13aa157' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -55,7 +55,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.2.6-c0bf0f679ce9-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.3.1-bd63e13aa157-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Update default to latest version, 7.3.1. 