### PR TITLE
Update dependencies and bump version post-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 sudo: false
 rvm:
 - 2.3.1
-- 2.5.1
+- 2.5.5
 addons:
   apt:
     packages:

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ source 'https://rubygems.org'
 chefspec_version = if Bundler.current_ruby.on_23?
                  '= 7.3.4'
                else
-                 '= 8.0.0'
+                 '= 8.0.1'
                end
 # Don't upgrade until https://github.com/Foodcritic/foodcritic/issues/760 is fixed
 foodcritic_version = '= 12.3.0'
-rubocop_version = '= 0.74.0'
+rubocop_version = '= 0.75.0'
 chef_vault_version = '> 3.0'
 
 chef_version = if Bundler.current_ruby.on_23?
@@ -16,6 +16,11 @@ chef_version = if Bundler.current_ruby.on_23?
                else
                  '= 14.13.11'
                end
+
+if Bundler.current_ruby.on_23?
+    # The latest version of faraday is not compatible with older versions of berkshelf
+    gem 'faraday', '< 0.16.0'
+end
 
 gem 'berkshelf'
 gem 'chef', chef_version

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.33.0'
+version          '2.34.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'


### PR DESCRIPTION
Update linting dependencies after the release.  Also had to add in a version constraint for faraday since the ruby 2.3.1 build is now failing after the recent release of faraday 0.16.x.

On a minor note, I realized Chef 14.13.11 ships with ruby 2.5.5 embedded, so updated travis to build with that instead of 2.5.1.