### PR TITLE
Fix splunk_app to handle moving files between filesystems

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.34.0'
+version          '2.33.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'


### PR DESCRIPTION
File.rename does not handle copying files between filesystems. So on certain setups, apps would fail to install with the following error:
```
Errno::EXDEV
------------
Invalid cross-device link @ rb_file_s_rename - (/tmp/kitchen/cache/test_app, /opt/splunk/etc/apps/test_app)
```
FileUtils.mv handles this and performs a copy/delete operation instead when this error occurs.
https://ruby-doc.org/stdlib-2.5.5/libdoc/fileutils/rdoc/FileUtils.html#method-c-mv