### PR TITLE
Update Splunk to 7.3.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -215,6 +215,7 @@ Vagrant.configure('2') do |config|
     default_omnibus config
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :s2_search, 'splunk_site2'
+      chef.add_recipe 'cerner_splunk_test::install_libarchive'
       chef.add_recipe 'cerner_splunk::search_head'
     end
     network cfg, :s2_search
@@ -224,6 +225,7 @@ Vagrant.configure('2') do |config|
     default_omnibus config
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :c1_search
+      chef.add_recipe 'cerner_splunk_test::install_libarchive'
       chef.add_recipe 'cerner_splunk::search_head'
     end
     network cfg, :c1_search
@@ -290,6 +292,7 @@ Vagrant.configure('2') do |config|
     default_omnibus config
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :f_default, 'splunk_standalone'
+      chef.add_recipe 'cerner_splunk_test::install_libarchive'
       chef.add_recipe 'cerner_splunk'
       chef.add_recipe 'cerner_splunk_test'
     end
@@ -298,9 +301,10 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :f_debian do |cfg|
     default_omnibus config
-    cfg.vm.box = 'bento/ubuntu-12.04'
+    cfg.vm.box = 'bento/ubuntu-16.04'
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :f_debian, 'splunk_standalone'
+      chef.add_recipe 'cerner_splunk_test::install_libarchive'
       chef.add_recipe 'cerner_splunk'
     end
     network cfg, :f_debian
@@ -310,6 +314,7 @@ Vagrant.configure('2') do |config|
     default_omnibus config
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :f_heavy, 'splunk_standalone'
+      chef.add_recipe 'cerner_splunk_test::install_libarchive'
       chef.add_recipe 'cerner_splunk::heavy_forwarder'
     end
     network cfg, :f_heavy

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,8 +13,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '7.3.1'
-default['splunk']['package']['build'] = 'bd63e13aa157'
+default['splunk']['package']['version'] = '7.3.2'
+default['splunk']['package']['build'] = 'c60db69f8e32'
 default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -18,8 +18,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`7.3.1`)
-* `node['splunk']['package']['build']` - Corresponding build number (`bd63e13aa157`)
+* `node['splunk']['package']['version']` - Major version to install (`7.3.2`)
+* `node['splunk']['package']['build']` - Corresponding build number (`c60db69f8e32`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/spec/cookbooks/cerner_splunk_test/recipes/install_libarchive.rb
+++ b/spec/cookbooks/cerner_splunk_test/recipes/install_libarchive.rb
@@ -11,7 +11,17 @@ execute 'remove files' do
   command 'rm -rf /opt/chef/embedded/lib/libarchive.so*'
 end
 
-package 'libarchive-devel' do
+if node['platform_family'] == 'debian'
+  libarchive_package = 'libarchive-dev'
+
+  execute 'apt-get update' do
+    command 'apt-get update'
+  end
+else
+  libarchive_package = 'libarchive-devel'
+end
+
+package libarchive_package do
   action :install
 end
 

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -40,7 +40,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-7.3.1-bd63e13aa157' }
+  let(:splunk_file) { 'splunkforwarder-7.3.2-c60db69f8e32' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -55,7 +55,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.3.1-bd63e13aa157-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-7.3.2-c60db69f8e32-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Mostly just updating Splunk to the latest release in the 7.x line.  However, when I tested all the vagrant boxes several of them had been missed in my previous commit to add support for mixlib-archive, so I went ahead and included those fixes in here too.