### PR TITLE
Add Support for Chef-client 15

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,12 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.35.0'
+version          '2.36.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 12.7', '< 15'
+chef_version     '>= 12.7', '< 16'
 
 depends          'chef-vault', '~> 3.0'
 depends          'ulimit', '~> 1.0'


### PR DESCRIPTION
# Details
* Adding Support for Chef-client 15
  * This cookbook's chef-client restriction is impacting other cookbooks that leverage it. The latest Chef-client version cannot be leveraged by any cookbooks that consume share a run-list with the cerner_splunk cookbook
* We would like to lift this restriction so that consuming cookbooks will be free to leverage the latest chef-client version