### PR TITLE
Post release gem updates, fix lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,13 +10,10 @@ AllCops:
 Metrics/BlockLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
-EachWithObject:
-  Enabled: false
-
-EmptyWhen:
+Lint/EmptyWhen:
   Enabled: false
 
 Metrics/MethodLength:
@@ -25,8 +22,17 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
+Style/EachWithObject:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
 
 Style/SignalException:
   EnforcedStyle: semantic

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,13 @@ source 'https://rubygems.org'
 chefspec_version = if Bundler.current_ruby.on_23?
                  '= 7.3.4'
                else
-                 '= 8.0.1'
+                 '= 9.1.0'
                end
-# Don't upgrade until https://github.com/Foodcritic/foodcritic/issues/760 is fixed
-foodcritic_version = '= 12.3.0'
-rubocop_version = '= 0.75.0'
-chef_vault_version = '> 3.0'
+
+foodcritic_version = '= 16.2.0'
+rubocop_version = '= 0.80.0'
+# chef-vault 4.x drops support for ruby 2.3
+chef_vault_version = '~> 3.0'
 
 chef_version = if Bundler.current_ruby.on_23?
                  '= 12.18.31'
@@ -29,8 +30,6 @@ gem 'chef', chef_version
 gem 'chef-sugar'
 gem 'chef-vault', chef_vault_version
 gem 'chefspec', chefspec_version
-# https://github.com/cucumber/cucumber-ruby-core/issues/160
-gem 'cucumber-core', '~> 3.2'
 gem 'foodcritic', foodcritic_version
 gem 'rubocop', rubocop_version
 gem 'ffi-libarchive'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Requirements
 * Red Hat Enterprise / CentOS 6.7+ / CentOS 7.0+ / Windows Server 2008+ (forwarder only) or Ubuntu LTS 12.04+
 * Chef 12+
 * Chef 14+
+* Chef 15+
 
 Getting your logs into Splunk
 -----------------------------

--- a/libraries/authentication.rb
+++ b/libraries/authentication.rb
@@ -18,7 +18,7 @@ module CernerSplunk
 
   # Module contains functions to configure authentication in a Splunk system
   module Authentication
-    def self.configure_authentication(node, hash) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, MethodLength
+    def self.configure_authentication(node, hash) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
       hash = hash.clone
       auth_stanzas = { 'authentication' => hash }
       fail 'authSettings is managed by chef. Don\'t set it yourself!' if hash.key?('authSettings')

--- a/libraries/conf_template.rb
+++ b/libraries/conf_template.rb
@@ -39,7 +39,7 @@ module CernerSplunk
       end
 
       # Compose two procs... I should monkey patch this in, but changing core ruby just seems wrong
-      def self.compose(g, f) # rubocop:disable Naming/UncommunicativeMethodParamName
+      def self.compose(g, f) # rubocop:disable Naming/MethodParameterName
         proc { |*a| g[*f[*a]] }
       end
 
@@ -49,7 +49,7 @@ module CernerSplunk
           @reader = CernerSplunk::Conf::Reader.new filename
         end
 
-        def [](x) # rubocop:disable Naming/UncommunicativeMethodParamName
+        def [](x) # rubocop:disable Naming/MethodParameterName
           data[x]
         end
 

--- a/libraries/databag.rb
+++ b/libraries/databag.rb
@@ -53,7 +53,7 @@ module CernerSplunk #:nodoc:
     # Converts an array of the form [data_bag,bag_item,key] to a string of the form "(data_bag/)bag_item(:key)"
     # If provided nil, will return nil
     # Inverse of to_a
-    def self.to_value(array, _options = {}) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+    def self.to_value(array, _options = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       case array
       when nil
         nil
@@ -75,7 +75,7 @@ module CernerSplunk #:nodoc:
 
     # Loads a data_bag item / based on the string
     # If provided nil or a string that doesn't resolve to a data_bag + item at least will return nil
-    def self.load(string, options = {}) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+    def self.load(string, options = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       opts = {
         pick_context: nil,
         handle_load_failure: false

--- a/libraries/lwrp.rb
+++ b/libraries/lwrp.rb
@@ -9,7 +9,7 @@
 # extend CernerSplunk::LWRP::(module) unless defined? (method name)
 
 require_relative 'databag'
-require_relative 'recipe'
+require_relative 'recipe_utils'
 
 module CernerSplunk
   # Methods involved with augmenting the LWRP syntax / writing recipies
@@ -39,7 +39,7 @@ module CernerSplunk
     #
     # Extension of the Resource DSL, defines an attribute that can be set upfront or can be calculated at convergence time.
     module DelayableAttribute
-      def delayable_attribute(attr_name, validation = {}) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+      def delayable_attribute(attr_name, validation = {}) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         class_eval(<<-SHIM, __FILE__, __LINE__ + 1)
           def #{attr_name}(arg=nil,&block)
             _set_or_return_#{attr_name}(arg,block)

--- a/libraries/passive_sensitive.rb
+++ b/libraries/passive_sensitive.rb
@@ -7,7 +7,7 @@ require 'chef/resource'
 
 class Chef # rubocop:disable Style/MultilineIfModifier
   # Making the sensitive attribute passive for older chef versions
-  class Resource # rubocop:disable Documentation
+  class Resource # rubocop:disable Style/Documentation
     def sensitive(args = nil)
       set_or_return(:sensitive, args, kind_of: [TrueClass, FalseClass])
     end

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # Cookbook Name:: cerner_splunk
-# File Name:: recipe.rb
+# File Name:: recipe_utils.rb
 #
-# This recipe contains utilities to help with Splunk Recipes.
+# This library contains utilities to help with Splunk Recipes.
 
 require_relative 'databag'
 

--- a/libraries/roles.rb
+++ b/libraries/roles.rb
@@ -8,7 +8,7 @@ require_relative 'databag'
 module CernerSplunk
   # Module contains functions to configure roles in a Splunk system
   module Roles
-    def self.configure_roles(hash) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, MethodLength
+    def self.configure_roles(hash) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
       user_prefs = {}
       authorize = {}
 

--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -133,7 +133,7 @@ require_relative 'conf'
 class Chef
   class Provider
     # Chef Provider for managing Splunk apps
-    class SplunkApp < Chef::Provider # rubocop:disable ClassLength
+    class SplunkApp < Chef::Provider # rubocop:disable Metrics/ClassLength
       provides :splunk_app if respond_to?(:provides)
 
       def whyrun_supported?
@@ -229,7 +229,7 @@ class Chef
         fail "Downloaded tarball for '#{new_resource.app}' has local entries" unless Dir[::File.join(temp_app_dir, 'local', '**', '*')].count { |file| ::File.file?(file) } == 0
       end
 
-      def should_install?(expected_version, installed_version, tar_version) # rubocop:disable PerceivedComplexity, CyclomaticComplexity
+      def should_install?(expected_version, installed_version, tar_version) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         fail "Downloaded tarball for #{new_resource.app} does not contain a version in app.conf!" unless tar_version.version
 
         # If we specify an expected version (see warning in should download), the tar version must match exactly OR the expected version is the base version of the (prerelease) tar version

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.36.0'
+version          '2.36.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/libraries/recipe_utils_spec.rb
+++ b/spec/unit/libraries/recipe_utils_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../spec_helper'
-require 'recipe'
+require 'recipe_utils'
 require 'splunk_app'
 
 describe 'CernerSplunk' do

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -132,7 +132,7 @@ describe 'cerner_splunk::_install' do
 
     context 'when platform is debian' do
       let(:platform) { 'ubuntu' }
-      let(:platform_version) { '14.04' }
+      let(:platform_version) { '18.04' }
 
       it 'installs downloaded splunk package and notifies splunk-first-run' do
         expected_attrs = {


### PR DESCRIPTION
Update linting and testing dependencies after the release.  The foodcritic issue still wasn't resolved so I applied the workaround to rename the recipe.rb library file. The cucumber issue was resolved though, so we no longer needed that version pin.