### PR TITLE
Remove unnecessary windows_password configs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -351,13 +351,16 @@ Vagrant.configure('2') do |config|
     cfg.vm.guest = :windows
     # config below prevents the installation of latest Chef on the box.
     # Reference: https://github.com/chef/vagrant-omnibus/issues/118
-    config.omnibus.install_url = 'https://packages.chef.io/files/stable/chef/14.5.27/windows/2012r2/chef-client-14.5.27-1-x64.msi'
+    # TODO: figure out how to install chef 15 on a windows box
+    cfg.omnibus.install_url = 'https://packages.chef.io/files/stable/chef/14.5.27/windows/2012r2/chef-client-14.5.27-1-x64.msi'
     cfg.vm.provider :virtualbox do |vb|
       vb.customize ['modifyvm', :id, '--memory', 1024]
     end
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :f_win2012r2, 'splunk_standalone'
+      chef.arguments = ''
       chef.add_role 'splunk_monitors_windows'
+      chef.add_recipe 'cerner_splunk_test::install_libarchive'
       chef.add_recipe 'cerner_splunk'
     end
     network cfg, :f_win2012r2, false

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -45,7 +45,6 @@ Configurable (with defaults)
 * `node['splunk']['forwarder_site']` - Set this attribute to configure site awareness for your forwarders.(`site0`)
 * `node['splunk']['mgmt_host']` - The host other SHC members use when connecting to the current node. You probably want a wrapper cookbook to override this. By default `node['splunk']['mgmt_interface']` is now used, but to support existing configurations this attribute is still available and takes precedence when set. (`nil`)
 * `node['splunk']['mgmt_interface']` - The network interface this node should use for communicating with other members of a SHC. (`node['network']['default_interface']`)
-* `node['splunk']['windows_password']` - This should be the name of a data bag item key where your windows password for the `Splunk` user is stored.
 * `node['splunk']['is_cloud']` - Set this attribute to `true` on cloud instances for Search Head Cluster (SHC). (`false`)
 * `node['splunk']['boot_start_args']` - Set splunk enabled boot-start arguments here. (` -systemd-managed 0`)
 * `node['splunk']['logs']` - Specify the contents of log-local.cfg, to override the default settings of Splunk's internal logging.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.36.1'
+version          '2.37.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -100,7 +100,7 @@ run_command = "#{node['splunk']['cmd']} help commands --accept-license --answer-
 run_command += " --seed-passwd 'changeme'" if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.2.0')
 
 # For windows, we accept the license during msi install so the ftr file will never be there.
-if !platform_family?('windows')
+unless platform_family?('windows')
   execute 'splunk-first-run' do
     command run_command
     user node['splunk']['user']

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -81,6 +81,7 @@ elsif platform_family? 'debian'
 elsif platform_family? 'windows'
   # installing as the system user by default as Splunk has difficulties with being a limited user
   flags = %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="#{node['splunk']['home'].tr('/', '\\')}")
+  # TODO: Use admin_password from databag for splunk-first-run.
   flags += ' SPLUNKPASSWORD=changeme' if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.1.0')
   windows_package node['splunk']['package']['base_name'] do
     source splunk_file
@@ -94,20 +95,18 @@ end
 
 include_recipe 'cerner_splunk::_configure_secret'
 
-windows_password = CernerSplunk::DataBag.load(node['splunk']['windows_password'], secret: node['splunk']['data_bag_secret'])
-
 run_command = "#{node['splunk']['cmd']} help commands --accept-license --answer-yes --no-prompt"
+# TODO: Use admin_password from databag for splunk-first-run.
 run_command += " --seed-passwd 'changeme'" if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.2.0')
 
-# TODO: Use admin_password from databag for splunk-first-run.
-execute 'splunk-first-run' do
-  command run_command
-  user node['splunk']['user']
-  group node['splunk']['group']
-  if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12.19.33')
-    password windows_password if platform_family?('windows')
+# For windows, we accept the license during msi install so the ftr file will never be there.
+if !platform_family?('windows')
+  execute 'splunk-first-run' do
+    command run_command
+    user node['splunk']['user']
+    group node['splunk']['group']
+    only_if { File.exist?("#{node['splunk']['home']}/ftr") }
   end
-  only_if { ::File.exist? "#{node['splunk']['home']}/ftr" }
 end
 
 ruby_block 'read splunk.secret' do

--- a/spec/cookbooks/cerner_splunk_test/recipes/install_libarchive.rb
+++ b/spec/cookbooks/cerner_splunk_test/recipes/install_libarchive.rb
@@ -9,6 +9,7 @@
 # So remove it and install the package ourselves.
 execute 'remove files' do
   command 'rm -rf /opt/chef/embedded/lib/libarchive.so*'
+  not_if { platform_family?('windows') }
 end
 
 if node['platform_family'] == 'debian'
@@ -23,6 +24,7 @@ end
 
 package libarchive_package do
   action :install
+  not_if { platform_family?('windows') }
 end
 
 chef_gem 'ffi-libarchive' do

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -11,7 +11,6 @@ describe 'cerner_splunk::_install' do
       node.override['splunk']['package']['download_group'] = 'universalforwarder'
       node.override['splunk']['package']['file_suffix'] = '.txt'
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
-      node.override['splunk']['windows_password'] = password_databag
     end
     runner.converge(described_recipe)
   end

--- a/spec/unit/recipes/_start_spec.rb
+++ b/spec/unit/recipes/_start_spec.rb
@@ -8,7 +8,6 @@ describe 'cerner_splunk::_start' do
       node.override['splunk']['cmd'] = 'splunk'
       node.override['splunk']['user'] = 'splunk'
       node.override['splunk']['config']['clusters'] = ['cerner_splunk/cluster']
-      node.override['splunk']['windows_password'] = password_databag
     end
     # Have to include forwarder recipe so that _start recipe can send notifications to services
     runner.converge('cerner_splunk::forwarder', described_recipe)

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -29,8 +29,7 @@
         }
       },
       "data_bag_secret": "/vagrant/vagrant_repo/alternative_encrypted_data_bag_secret",
-      "mgmt_interface": "eth1",
-      "windows_password": "cerner_splunk/passwords:winpass"
+      "mgmt_interface": "eth1"
     }
   }
 }


### PR DESCRIPTION
It turns out, we were requiring users to configure a value that was never actually used.  See the comments inline for additional information.