### PR TITLE
Removed deprecated vagrant-omnibus plugin dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.37.0'
+version          '2.37.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'


### PR DESCRIPTION
Turns out, I mostly just needed to upgrade to a newer version of vagrant in order to get things working on the windows box.  They made a fix in 2.2.5 around detecting the version of chef that was installed.  But in looking at that, I realized vagrant supports installing a specified version of chef out of the box. So the vagrant-omnibus plugin is completely unnecessary.  I'm guessing maybe back in the day when it was added, vagrant didn't support the chef install?

https://www.vagrantup.com/docs/provisioning/chef_common.html