### PR TITLE
Rename master branch to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
     packages:
       - libarchive-dev
 script:
+- bundle exec rubocop rubocop --version
 - bundle exec rubocop
+- bundle exec rubocop foodcritic --version
 - bundle exec foodcritic -f any .
 - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
     packages:
       - libarchive-dev
 script:
-- bundle exec rubocop rubocop --version
+- bundle exec rubocop --version
 - bundle exec rubocop
-- bundle exec rubocop foodcritic --version
+- bundle exec foodcritic --version
 - bundle exec foodcritic -f any .
 - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   except:
-    - master
+    - main
 language: ruby
 cache: bundler
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ addons:
     packages:
       - libarchive-dev
 script:
-- bundle exec rubocop --version
 - bundle exec rubocop
-- bundle exec foodcritic --version
 - bundle exec foodcritic -f any .
 - bundle exec rspec

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 3. The pull request is merged 
     1. Manually, not using github issues so a fast forward of stable can be done
     2. The annotated tag is created of the reviewed release text
-    3. Master is set to the annotated tag
+    3. Main is set to the annotated tag
 4. Release to supermarket 
 5. Cleanup
     1. The issue and existing milestone is closed

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,14 +3,14 @@ Contributing & Community Resources
 
 Branch Strategy
 ---------------
-  * `master` is the latest release tag
+  * `main` is the latest release tag
   * `stable` is the version under development
   * Feature branches should be branched from / merged into `stable`
 
 Issue Tracking
 --------------
   * Submit issues in github issues. 
-  * If it's being tracked internally, you may see references to OPSINFRA and DEVOPS JIRAs
+  * If it's being tracked internally, you may see references to JIRAs
 
 Communities & Resources
 -----------------------

--- a/libraries/passive_sensitive.rb
+++ b/libraries/passive_sensitive.rb
@@ -4,12 +4,13 @@
 # File Name:: passive_sensitive.rb
 
 require 'chef/resource'
-
+# rubocop:disable Style/Documentation
 class Chef # rubocop:disable Style/MultilineIfModifier
   # Making the sensitive attribute passive for older chef versions
-  class Resource # rubocop:disable Style/Documentation
+  class Resource
     def sensitive(args = nil)
       set_or_return(:sensitive, args, kind_of: [TrueClass, FalseClass])
     end
   end
 end unless Chef::Resource.method_defined? :sensitive
+# rubocop:enable Style/Documentation

--- a/libraries/passive_sensitive.rb
+++ b/libraries/passive_sensitive.rb
@@ -4,13 +4,12 @@
 # File Name:: passive_sensitive.rb
 
 require 'chef/resource'
-# rubocop:disable Style/Documentation
+
 class Chef # rubocop:disable Style/MultilineIfModifier
   # Making the sensitive attribute passive for older chef versions
-  class Resource
+  class Resource # rubocop:disable Style/Documentation, Lint/RedundantCopDisableDirective
     def sensitive(args = nil)
       set_or_return(:sensitive, args, kind_of: [TrueClass, FalseClass])
     end
   end
 end unless Chef::Resource.method_defined? :sensitive
-# rubocop:enable Style/Documentation


### PR DESCRIPTION
I already created a new branch named main per the instructions here:
https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx

This is just to cleanup any remaining documentation references to it.