### PR TITLE
Loosening up upper limit for chef-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 - 2.3.1
 - 2.5.5
 - 2.6.5
+- 2.7.1
 addons:
   apt:
     packages:

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ chef_version = if Bundler.current_ruby.on_23?
                elsif Bundler.current_ruby.on_25?
                  '= 14.13.11'
                else
-                 '= 15.8.23'
+                 '= 16.2.73'
                end
 
 if Bundler.current_ruby.on_23?

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,10 @@ chef_version = if Bundler.current_ruby.on_23?
                  '= 12.18.31'
                elsif Bundler.current_ruby.on_25?
                  '= 14.13.11'
+               elsif Bundler.current_ruby.on_26?
+                 '= 15.8.23'
                else
-                 '= 16.2.73'
+                 '= 16.3.45'
                end
 
 if Bundler.current_ruby.on_23?

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Requirements
 * Chef 12+
 * Chef 14+
 * Chef 15+
+* Chef 16+
 
 Getting your logs into Splunk
 -----------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ def network(config, name, splunk_password = true)
 end
 
 def chef_defaults(chef, name, environment = 'splunk_server')
-  chef.version = '15'
+  chef.version = '16'
   chef.arguments = "--chef-license accept"
   chef.environment = environment
   chef.chef_server_url = "http://#{@chefip}:4000/"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,12 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.38.0'
+version          '2.39.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 12.7', '< 16'
+chef_version     '>= 12.7'
 
 depends          'chef-vault', '~> 3.0'
 depends          'ulimit', '~> 1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '2.39.0'
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 12.7'
+chef_version     '>= 12.7', '< 17'
 
 depends          'chef-vault', '~> 3.0'
 depends          'ulimit', '~> 1.0'

--- a/providers/sh_cluster.rb
+++ b/providers/sh_cluster.rb
@@ -4,6 +4,8 @@
 # Provider:: sh_cluster
 #
 
+provides :sh_cluster if respond_to?(:provides)
+
 action :initialize do
   search_heads = new_resource.search_heads
   admin_password = new_resource.admin_password


### PR DESCRIPTION
We are doing internal uplift for chef-client for all cookbooks. We want to support latest two chef-client version which would be 15.x & 16.x. This PR lifts the upper limit so consumer can run it with 16. 

Please review. @acharlieh @gravesb Let me know if I am missing anything. I tested all vagrant suites locally. They converged successfully. 