### PR TITLE
Loosen version restriction on chef-vault

### DIFF
--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -325,7 +325,7 @@ class Chef
         proc_sym = data['proc'].to_sym
         data = symbolize_keys(data).reject { |k, _| k == :proc }
         arguments = context.merge data
-        source_module.send proc_sym, arguments
+        source_module.send proc_sym, **arguments
       end
 
       def insert_procs(filename, contents)

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
 chef_version     '>= 12.7', '< 17'
 
-depends          'chef-vault', '~> 3.0'
+depends          'chef-vault', '> 3.0'
 depends          'ulimit', '~> 1.0'
 depends          'line', '~> 2.0'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.40.0'
+version          '2.41.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'


### PR DESCRIPTION
When running on Chef Client 15.13.8 and above, the following deprecation warning is present:
```
Resource chef_vault_secret needs `provides :chef_vault_secret` in addition to `resource_name :chef_vault_secret` declaration
Please see https://docs.chef.io/deprecations_resource_name_without_provides/ for further details and information on how to correct this problem.
```
This has been corrected in chef-vault 4.0.3, so we need to open up the version restriction to allow for newer versions of chef-vault to be used with cerner_splunk.

I didn't put an upper limit because I don't believe the chef-vault cookbook will be getting much more development, if any, because it is now included in the [Chef Infra client package as of Chef 16](https://docs.chef.io/release_notes/#chef-vault-functionality-out-of-the-box). Once we drop support for older chef clients (< 16), we can remove it from the metadata entirely.