### PR TITLE
Fix issue with configuring multiple multi-site clusters for searching

### DIFF
--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -325,7 +325,7 @@ class Chef
         proc_sym = data['proc'].to_sym
         data = symbolize_keys(data).reject { |k, _| k == :proc }
         arguments = context.merge data
-        source_module.send proc_sym, **arguments
+        source_module.send proc_sym, arguments
       end
 
       def insert_procs(filename, contents)

--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -325,7 +325,7 @@ class Chef
         proc_sym = data['proc'].to_sym
         data = symbolize_keys(data).reject { |k, _| k == :proc }
         arguments = context.merge data
-        source_module.send proc_sym, arguments
+        source_module.send proc_sym, **arguments
       end
 
       def insert_procs(filename, contents)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.39.0'
+version          '2.40.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -16,7 +16,8 @@
         "clusters": [
           "cerner_splunk/cluster-vagrant-site1",
           "cerner_splunk/cluster-standalone",
-          "cerner_splunk/cluster-vagrant"
+          "cerner_splunk/cluster-vagrant",
+          "cerner_splunk/cluster-vagrant-site2"
         ],
         "roles": "cerner_splunk/authnz-vagrant:roles",
         "authentication": "cerner_splunk/authnz-vagrant:authn",


### PR DESCRIPTION
When specifying multiple clusters in the splunk/config/clusters array, only the first element would have the multi-site attributes loaded properly.  If a multi-site cluster was in any other position in the array, it would essentially be ignored and nothing would be added to server.conf to use it as a search peer.  This corrects the issue and adds some unit tests around it.