### PR TITLE
Post-release gem updates, fixed new lint and warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,12 @@ Layout/LineLength:
 Lint/EmptyWhen:
   Enabled: false
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/MethodLength:
   Max: 40
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,12 @@ source 'https://rubygems.org'
 chefspec_version = if Bundler.current_ruby.on_23?
                  '= 7.3.4'
                else
-                 '= 9.1.0'
+                 '= 9.2.1'
                end
 
-foodcritic_version = '= 16.2.0'
-rubocop_version = '= 0.80.0'
+foodcritic_version = '= 16.3.0'
+# rubocop 0.82 drops support for ruby 2.3
+rubocop_version = '= 0.81.0'
 # chef-vault 4.x drops support for ruby 2.3
 chef_vault_version = '~> 3.0'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.41.0'
+version          '2.41.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/recipes/_configure_secret_spec.rb
+++ b/spec/unit/recipes/_configure_secret_spec.rb
@@ -13,7 +13,7 @@ describe 'cerner_splunk::_configure_secret' do
   end
 
   let(:platform) { 'centos' }
-  let(:platform_version) { '6.9' }
+  let(:platform_version) { '7.7.1908' }
   let(:node_type) { :server }
 
   context 'when the secret is configured for the current node' do

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -119,7 +119,7 @@ describe 'cerner_splunk::_install' do
 
     context 'when platform is rhel' do
       let(:platform) { 'centos' }
-      let(:platform_version) { '6.9' }
+      let(:platform_version) { '7.7.1908' }
 
       it 'installs downloaded splunk package and notifies splunk-first-run' do
         expected_attrs = {

--- a/spec/unit/recipes/_migrate_forwarder_spec.rb
+++ b/spec/unit/recipes/_migrate_forwarder_spec.rb
@@ -41,7 +41,7 @@ describe 'cerner_splunk::_migrate_forwarder' do
 
   context 'when platform family is linux' do
     let(:platform) { 'centos' }
-    let(:platform_version) { '6.9' }
+    let(:platform_version) { '7.7.1908' }
 
     it 'deletes the splunk home directory' do
       expect(subject).to delete_directory('/opt/splunkforwarder')


### PR DESCRIPTION
Update linting and testing dependencies after the release.

We'll likely drop support for ruby 2.3 in the very near future, but I didn't want to mix that in here.