### PR TITLE
Fix install idempotency on windows

### DIFF
--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -15,7 +15,7 @@ node.default['splunk']['package']['name'] = "#{nsp['base_name']}-#{nsp['version'
 node.default['splunk']['package']['file_name'] = "#{nsp['name']}#{nsp['file_suffix']}"
 node.default['splunk']['package']['url'] =
   "#{nsp['base_url']}/#{nsp['download_group']}/releases/#{nsp['version']}/#{nsp['platform']}/#{nsp['file_name']}"
-node.default['splunk']['home'] = CernerSplunk.splunk_home(node['platform_family'], node['kernel']['machine'], nsp['base_name'])
+node.default['splunk']['home'] = CernerSplunk.splunk_home(node['platform_family'], node['kernel']['machine'], CernerSplunk.installed_package_name(node['platform_family'], node['splunk']['package']['base_name']))
 node.default['splunk']['cmd'] = CernerSplunk.splunk_command(node)
 
 service = CernerSplunk.splunk_service_name(node['platform_family'], nsp['base_name'])
@@ -83,9 +83,9 @@ elsif platform_family? 'windows'
   flags = %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="#{node['splunk']['home'].tr('/', '\\')}")
   # TODO: Use admin_password from databag for splunk-first-run.
   flags += ' SPLUNKPASSWORD=changeme' if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.1.0')
-  windows_package node['splunk']['package']['base_name'] do
-    source splunk_file
-    version "#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"
+  windows_package CernerSplunk.installed_package_name(node['platform_family'], node['splunk']['package']['base_name']) do
+    source node['splunk']['package']['url']
+    version node['splunk']['package']['version']
     only_if(&manifest_missing)
     options flags
   end

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -84,7 +84,7 @@ elsif platform_family? 'windows'
   # TODO: Use admin_password from databag for splunk-first-run.
   flags += ' SPLUNKPASSWORD=changeme' if Gem::Version.new(nsp['version']) >= Gem::Version.new('7.1.0')
   windows_package CernerSplunk.installed_package_name(node['platform_family'], node['splunk']['package']['base_name']) do
-    source node['splunk']['package']['url']
+    source splunk_file
     version node['splunk']['package']['version']
     only_if(&manifest_missing)
     options flags

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -111,9 +111,9 @@ describe 'cerner_splunk::_install' do
       it 'installs downloaded splunk package' do
         expected_attrs = {
           source: splunk_filepath,
-          options: %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="test\\splunkforwarder" SPLUNKPASSWORD=changeme)
+          options: %(AGREETOLICENSE=Yes SERVICESTARTTYPE=auto LAUNCHSPLUNK=0 INSTALLDIR="test\\UniversalForwarder" SPLUNKPASSWORD=changeme)
         }
-        expect(subject).to install_windows_package('splunkforwarder').with(expected_attrs)
+        expect(subject).to install_windows_package('UniversalForwarder').with(expected_attrs)
       end
     end
 


### PR DESCRIPTION
The splunk_home attribute was being set based purely on the base_name attribute, which is not correct on windows. By calling the existing library function `CernerSplunk.installed_package_name`, the actual home directory can be found and the existence of the manifest verified. Prior to this, installation on windows would be attempted every time `_install` ran, resulting in success on the first run and failure on any subsequent runs.

Additionally, the same is now called on the package name for the `windows_package` resource so it can be properly checked against the uninstall registry keys, and the version no longer appends the build ID as that only a characteristic of linux package management.