### PR TITLE
Update to latest Chef 16 to fix failing travis build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ chef_version = if Bundler.current_ruby.on_23?
                elsif Bundler.current_ruby.on_26?
                  '= 15.8.23'
                else
-                 '= 16.3.45'
+                 '= 16.6.14'
                end
 
 if Bundler.current_ruby.on_23?


### PR DESCRIPTION
I noticed the Ruby 2.7.1 build was failing in PR #226.  Just needed to update to the latest version of Chef due to changes in untracked transitive dependencies (ohai).