### PR TITLE
Drop support for EOL ruby and chef versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Exclude:
     - 'Vagrantfile'
     - 'Gemfile'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.3.1
 - 2.5.5
 - 2.6.5
 - 2.7.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,32 +1,20 @@
 source 'https://rubygems.org'
 
 # Going forward, these should be updated to the latest versions immediately post release
-chefspec_version = if Bundler.current_ruby.on_23?
-                 '= 7.3.4'
-               else
-                 '= 9.2.1'
-               end
+chefspec_version = '= 9.2.1'
 
 foodcritic_version = '= 16.3.0'
-# rubocop 0.82 drops support for ruby 2.3
 rubocop_version = '= 0.81.0'
-# chef-vault 4.x drops support for ruby 2.3
-chef_vault_version = '~> 3.0'
 
-chef_version = if Bundler.current_ruby.on_23?
-                 '= 12.18.31'
-               elsif Bundler.current_ruby.on_25?
+chef_vault_version = '~> 4.0'
+
+chef_version = if Bundler.current_ruby.on_25?
                  '= 14.13.11'
                elsif Bundler.current_ruby.on_26?
                  '= 15.8.23'
                else
                  '= 16.6.14'
                end
-
-if Bundler.current_ruby.on_23?
-    # The latest version of faraday is not compatible with older versions of berkshelf
-    gem 'faraday', '< 0.16.0'
-end
 
 gem 'berkshelf'
 gem 'chef', chef_version

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Based on the work done by [BBY Solutions](https://github.com/bestbuycom/splunk_c
 Requirements
 ------------
 * Red Hat Enterprise / CentOS 6.7+ / CentOS 7.0+ / Windows Server 2008+ (forwarder only) or Ubuntu LTS 12.04+
-* Chef 12+
 * Chef 14+
 * Chef 15+
 * Chef 16+

--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -318,7 +318,7 @@ class Chef
       end
 
       def symbolize_keys(hash)
-        Hash[hash.map { |k, v| [k.to_sym, v] }]
+        Hash[hash.transform_keys(&:to_sym)]
       end
 
       def hash_to_proc(source_module, data, context = {})

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,12 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.42.1'
+version          '2.43.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 12.7', '< 17'
+chef_version     '>= 14', '< 17'
 
 depends          'chef-vault', '> 3.0'
 depends          'ulimit', '~> 1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.42.0'
+version          '2.42.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
@@ -15,7 +15,7 @@ chef_version     '>= 12.7', '< 17'
 
 depends          'chef-vault', '> 3.0'
 depends          'ulimit', '~> 1.0'
-depends          'line', '~> 2.0'
+depends          'line', '~> 2.1'
 
 supports         'redhat', '>= 6.7'
 supports         'ubuntu', '>= 12.04'


### PR DESCRIPTION
Fixes #230.

Per https://github.com/sous-chefs/line/blob/master/CHANGELOG.md#210---2018-09-28 it appears filter_lines was not added until 2.1.0 so that should be the minimum declared version.

Edit: The ruby 2.3 travis test was failing, so rather than fixing it I'm removing support and testing for some old EOL ruby and chef versions.  Since that's a more impactful change, I updated the PR title accordingly.