### PR TITLE
Prevent double encryption of $7$ values, version bump

### DIFF
--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -12,8 +12,7 @@ module CernerSplunk
   # parameter xor controls the XOR logic.
   def self.splunk_encrypt_password(plain_text, splunk_secret, xor = true)
     # Prevent double encrypting values
-    return plain_text if plain_text.start_with? '$1$'
-    return plain_text if plain_text.start_with? '$7$'
+    return plain_text if plain_text.start_with? '$1$', '$7$'
 
     rc4key = splunk_secret.strip[0..15]
 

--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -13,6 +13,7 @@ module CernerSplunk
   def self.splunk_encrypt_password(plain_text, splunk_secret, xor = true)
     # Prevent double encrypting values
     return plain_text if plain_text.start_with? '$1$'
+    return plain_text if plain_text.start_with? '$7$'
 
     rc4key = splunk_secret.strip[0..15]
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.45.0'
+version          '2.46.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -6,10 +6,10 @@ require 'rc4'
 
 describe 'CernerSplunk::splunk_password' do
   let(:splunk_secret) { 'qYFEHts8G0E/ABbp' }
-  let(:password) { 'password' || '$1$password' || '$7$password' }
+  let(:password) { 'password' }
 
   describe '.splunk_encrypt_password' do
-    context 'when the password has already been encrypted' do
+    context 'when the password has already been encrypted by pre splunk 7.2' do
       let(:password) { '$1$RhLQiUyG3Qc7' }
 
       it 'does not re-encrypt it again' do
@@ -17,15 +17,7 @@ describe 'CernerSplunk::splunk_password' do
         expect(encrypted).to eq(password)
       end
     end
-    context 'when the password has already been encrypted' do
-      let(:password) { '$1$password' }
-
-      it 'does not re-encrypt it again' do
-        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
-        expect(encrypted).to eq(password)
-      end
-    end
-    context 'when the password has already been encrypted' do
+    context 'when the password has already been encrypted by splunk 7.2+' do
       let(:password) { '$7$password' }
 
       it 'does not re-encrypt it again' do

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -19,7 +19,7 @@ describe 'CernerSplunk::splunk_password' do
     end
     context 'when the password has already been encrypted' do
       let(:password) { '$1$password' }
-  
+
       it 'does not re-encrypt it again' do
         encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
         expect(encrypted).to eq(password)
@@ -27,7 +27,7 @@ describe 'CernerSplunk::splunk_password' do
     end
     context 'when the password has already been encrypted' do
       let(:password) { '$7$password' }
-    
+
       it 'does not re-encrypt it again' do
         encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
         expect(encrypted).to eq(password)

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -10,8 +10,24 @@ describe 'CernerSplunk::splunk_password' do
 
   describe '.splunk_encrypt_password' do
     context 'when the password has already been encrypted' do
-      let(:password) { '$1$RhLQiUyG3Qc7' || '$1$password' || '$7$password' }
+      let(:password) { '$1$RhLQiUyG3Qc7' }
 
+      it 'does not re-encrypt it again' do
+        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
+        expect(encrypted).to eq(password)
+      end
+    end
+    context 'when the password has already been encrypted' do
+      let(:password) { '$1$password' }
+  
+      it 'does not re-encrypt it again' do
+        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
+        expect(encrypted).to eq(password)
+      end
+    end
+    context 'when the password has already been encrypted' do
+      let(:password) { '$7$password' }
+    
       it 'does not re-encrypt it again' do
         encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
         expect(encrypted).to eq(password)

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -6,11 +6,11 @@ require 'rc4'
 
 describe 'CernerSplunk::splunk_password' do
   let(:splunk_secret) { 'qYFEHts8G0E/ABbp' }
-  let(:password) { 'password' }
+  let(:password) { 'password' || '$1$password' || '$7$password' }
 
   describe '.splunk_encrypt_password' do
     context 'when the password has already been encrypted' do
-      let(:password) { '$1$RhLQiUyG3Qc7' }
+      let(:password) { '$1$RhLQiUyG3Qc7' || '$1$password' || '$7$password' }
 
       it 'does not re-encrypt it again' do
         encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)


### PR DESCRIPTION
This is to prevent cerner_splunk from double-encrypting passwords starting with $7$.

I was able to verify this works without replacing any certs, I changed the default from `password` to `$1$password` and `$7$password` and let `vagrant up` get to where it fails because of `_generate_password.rb` and verified that `sslPassword` was in plaintext.

```
sslPassword = password
[sslConfig]
sslPassword = $1$EV6E1QnAllU7

sslPassword = $1$password
[sslConfig]
sslPassword = $1$password

sslPassword = $7$password
[sslConfig]
sslPassword = $7$password
```