### PR TITLE
Use splunk start when upgrading Splunk with systemd to 8.0 or 8.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -303,7 +303,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.define :f_win2012r2 do |cfg|
-    cfg.vm.box = 'opentable/win-2012r2-standard-amd64-nocm'
+    cfg.vm.box = 'mwrock/Windows2012R2'
 
     cfg.vm.provider :virtualbox do |vb|
       vb.customize ['modifyvm', :id, '--memory', 1024]

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -133,7 +133,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
     previous_version = Gem::Version.new(previous_splunk_version)
     current_version = Gem::Version.new(node['splunk']['package']['version'])
 
-    return true if previous_version <= Gem::Version.new('7.4.0') && current_version >= Gem::Version.new('8.0.0')
+    return true if previous_version < Gem::Version.new('8.0.0') && current_version >= Gem::Version.new('8.0.0')
 
     return true if previous_version < Gem::Version.new('8.1.0') && current_version >= Gem::Version.new('8.1.0')
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.46.0'
+version          '2.47.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'


### PR DESCRIPTION
Fixes #235.

See https://docs.splunk.com/Documentation/Splunk/8.1.3/Admin/RunSplunkassystemdservice#Upgrade_considerations_for_systemd for additional details.