### PR TITLE
Restore support for Splunk 7.2 and below

### DIFF
--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -41,14 +41,14 @@ default['splunk']['boot_start_args'] =
   if platform_family? 'rhel', 'fedora', 'amazon'
     case node['platform_version'].to_i
     when 6
-      ' -systemd-managed 0'
+      '-systemd-managed 0'
     when 7
-      ' -systemd-managed 1 -systemd-unit-file-name splunk'
+      '-systemd-managed 1 -systemd-unit-file-name splunk'
     else
-      ' -systemd-managed 0'
+      '-systemd-managed 0'
     end
   else
-    ' -systemd-managed 0'
+    '-systemd-managed 0'
   end
 
 # Default systemd file location based on default systemd unit file name

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.47.0'
+version          '2.47.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -10,8 +10,10 @@ init_file_path = '/etc/init.d/splunk'
 restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).grep(/#{ulimit_command}/).any?)
 
 # We want to always ensure that the boot-start script is in place on non-windows platforms
-command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']} -group #{node['splunk']['group']}"
-command += node['splunk']['boot_start_args'] if Gem::Version.new(node['splunk']['package']['version']) >= Gem::Version.new('7.2.2')
+package_version = Gem::Version.new(node['splunk']['package']['version'])
+command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
+command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
+command += " #{node['splunk']['boot_start_args']}" if package_version >= Gem::Version.new('7.2.2')
 
 execute command do
   not_if { platform_family?('windows') }
@@ -48,7 +50,7 @@ filter_lines 'update-systemd-file' do
             { stanza: ['Service', { KillMode: 'mixed', KillSignal: 'SIGINT', TimeoutStopSec: '10min' }] }
           ])
   sensitive false
-  only_if { File.exist?(node['splunk']['systemd_file_location']) && Gem::Version.new(node['splunk']['package']['version']) < Gem::Version.new('8.0.0') }
+  only_if { File.exist?(node['splunk']['systemd_file_location']) && package_version < Gem::Version.new('8.0.0') }
   notifies :run, 'execute[reload-systemctl]', :immediately
 end
 

--- a/spec/unit/recipes/_start_spec.rb
+++ b/spec/unit/recipes/_start_spec.rb
@@ -143,7 +143,7 @@ describe 'cerner_splunk::_start' do
     end
 
     context 'and platform version is 7.x' do
-      let(:platform_version) { '7.6.1810' }
+      let(:platform_version) { '7.8.2003' }
 
       context 'and the splunk version is less than 8.0.0' do
         let(:package_version) { '7.2.10' }

--- a/spec/unit/recipes/_start_spec.rb
+++ b/spec/unit/recipes/_start_spec.rb
@@ -146,13 +146,13 @@ describe 'cerner_splunk::_start' do
       let(:platform_version) { '7.6.1810' }
 
       context 'and the splunk version is less than 8.0.0' do
-        let(:package_version) { '7.3.9' }
+        let(:package_version) { '7.2.10' }
 
         context 'when systemd script does not exist' do
           let(:systemd_exists) { [false, true] }
 
           it 'executes boot-start script for systemd' do
-            expect(subject).to run_execute('splunk enable boot-start -user splunk -group splunk -systemd-managed 1 -systemd-unit-file-name splunk')
+            expect(subject).to run_execute('splunk enable boot-start -user splunk -systemd-managed 1 -systemd-unit-file-name splunk')
           end
 
           it 'modifies the systemd file' do


### PR DESCRIPTION
It was brought to my attention that the -group argument being a part of the boot-start command was causing failures on older versions of Splunk.  Based on the documentation it looks like it was added in 8.1.0, but in testing I was able to see it working fine all the way back to 7.3.0.  However as soon as I dropped below that, I started seeing the reported failures.  So this just pulls out the -group argument into a separate conditional so it's only added in 7.3 or above.

I debated about restoring support for older versions considering 7.2 just dropped out of Support for Splunk Enterprise. However, the UF for 7.2 is still under limited (P3 or below) support until Oct 2023 so I think it makes sense for the cookbook to continue supporting those versions as well.