### PR TITLE
Allow for configurable Splunk user home directory

### DIFF
--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -42,7 +42,7 @@ default['splunk']['boot_start_args'] =
     case node['platform_version'].to_i
     when 6
       '-systemd-managed 0'
-    when 7
+    when 7, 8
       '-systemd-managed 1 -systemd-unit-file-name splunk'
     else
       '-systemd-managed 0'

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -10,6 +10,7 @@ Configurable (with defaults)
 -----------------------------
 * `node['splunk']['exclude_groups']` - Array of local groups to which the splunk user should not belong. Checking existing memberships and removing the splunk user from these groups during the chef run only works on Chef 11.10+, users of prior versions should remove the splunk user from these groups manually. (`['root','wheel','admin']`)
 * `node['splunk']['groups']` - Array of local groups to which splunk user should be a member in addition to `node['splunk']['group']`. ([] - no additional groups)
+* `node['splunk']['user_home']` - The home directory to set for the splunk user. If unset the home directory will be the one created by the splunk package install in node['splunk']['home'] (nil - no default)
 * `node['splunk']['main_project_index']` - Index to send all configured monitors to by default (nil - no default)
 * `node['splunk']['monitors']` - Array of Hashes, to setup Monitoring stanzas (empty - no monitors)
   * `node['splunk']['monitors'][]['path']` - Path to monitor !!Required!!

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.48.0'
+version          '2.49.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/_user_management.rb
+++ b/recipes/_user_management.rb
@@ -8,10 +8,20 @@
 # User management currently not supported on windows
 return if platform_family?('windows')
 
+home_directory = node['splunk']['user_home']
 # user should be created by the package install
 user node['splunk']['user'] do
-  manage_home true
+  manage_home false
+  home home_directory if home_directory
   action %i[create lock]
+end
+
+if home_directory
+  directory home_directory do
+    user node['splunk']['user']
+    group node['splunk']['group']
+    mode '0700'
+  end
 end
 
 conflicts = node['splunk']['groups'].find_all do |group_to_add|

--- a/spec/unit/recipes/_user_management_spec.rb
+++ b/spec/unit/recipes/_user_management_spec.rb
@@ -46,6 +46,10 @@ describe 'cerner_splunk::_user_management' do
         }
         expect(subject).to create_user('splunk').with(expected_attrs)
       end
+
+      it 'does not ensure the home directory exists' do
+        expect(subject).not_to create_directory('/home/splunk')
+      end
     end
 
     context 'when the user_home is set' do
@@ -64,7 +68,7 @@ describe 'cerner_splunk::_user_management' do
           group: 'splunk',
           mode: '0700'
         }
-        expect(subject).to create_directory(user_home).with(expected_attrs)
+        expect(subject).to create_directory('/home/splunk').with(expected_attrs)
       end
     end
   end

--- a/spec/unit/recipes/_user_management_spec.rb
+++ b/spec/unit/recipes/_user_management_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'cerner_splunk::_user_management' do
+  subject do
+    runner = ChefSpec::SoloRunner.new(platform: platform, version: platform_version) do |node|
+      node.override['splunk']['user'] = 'splunk'
+      node.override['splunk']['user_home'] = user_home
+    end
+    runner.converge('cerner_splunk::_restart_marker', described_recipe)
+  end
+
+  let(:platform) { 'centos' }
+  let(:platform_version) { '6.10' }
+  let(:user_home) { nil }
+
+  let(:windows) { nil }
+
+  before do
+    allow(Chef::Recipe).to receive(:platform_family?).with('windows').and_return(windows)
+  end
+
+  after do
+    CernerSplunk.reset
+  end
+
+  context 'when platform is windows' do
+    let(:platform) { 'windows' }
+    let(:platform_version) { '2012R2' }
+    let(:windows) { true }
+
+    it 'does nothing' do
+      expect(subject).not_to create_user('splunk')
+    end
+  end
+
+  context 'when platform is rhel' do
+    let(:platform) { 'centos' }
+    let(:platform_version) { '8' }
+
+    context 'when the user_home is not set' do
+      it 'ensures the splunk user exists' do
+        expected_attrs = {
+          manage_home: false
+        }
+        expect(subject).to create_user('splunk').with(expected_attrs)
+      end
+    end
+
+    context 'when the user_home is set' do
+      let(:user_home) { '/home/splunk' }
+      it 'ensures the splunk user exists with the configured home directory' do
+        expected_attrs = {
+          manage_home: false,
+          home: user_home
+        }
+        expect(subject).to create_user('splunk').with(expected_attrs)
+      end
+
+      it 'ensures the home directory exists' do
+        expected_attrs = {
+          user: 'splunk',
+          group: 'splunk',
+          mode: '0700'
+        }
+        expect(subject).to create_directory(user_home).with(expected_attrs)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For consistency, some systems may want all users to have the same base home directory.  The splunk user created by the splunk package installation has the home directory defaulted to SPLUNK_HOME (/opt/splunk).  This enhancement keeps that as the default behavior but allows consumers to configure a different home directory if they so choose.