### PR TITLE
Update default version to 8.1.6

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,10 +13,10 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '8.1.2'
-default['splunk']['package']['build'] = '545206cc9f70'
+default['splunk']['package']['version'] = '8.1.6'
+default['splunk']['package']['build'] = 'c1a0dd183ee5'
 default['splunk']['is_cloud'] = false
-default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
+default['splunk']['package']['base_url'] = 'https://d7wz6hmoaavd0.cloudfront.net/products'
 default['splunk']['package']['platform'] = node['os']
 default['splunk']['package']['file_suffix'] =
   case node['platform_family']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -19,8 +19,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`8.1.2`)
-* `node['splunk']['package']['build']` - Corresponding build number (`545206cc9f70`)
+* `node['splunk']['package']['version']` - Major version to install (`8.1.6`)
+* `node['splunk']['package']['build']` - Corresponding build number (`c1a0dd183ee5`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.51.0'
+version          '2.52.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -39,7 +39,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-8.1.2-545206cc9f70' }
+  let(:splunk_file) { 'splunkforwarder-8.1.6-c1a0dd183ee5' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -54,7 +54,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-8.1.2-545206cc9f70-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-8.1.6-c1a0dd183ee5-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Updating the default version to the latest in the 8.1.x line.  The old url (download.splunk.com) worked fine up until 8.1.5, but 8.1.6 is not available there.  I have my doubts about how permanent this new cloudfront url is, but that's what the website provides when you go to download a new version from it.  We'll just have to keep an eye on it to see if it changes.