### PR TITLE
Update default version to 8.1.8

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,8 +13,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '8.1.7.2'
-default['splunk']['package']['build'] = 'dc318a6952c4'
+default['splunk']['package']['version'] = '8.1.8'
+default['splunk']['package']['build'] = '39da583cc695'
 default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -19,8 +19,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`8.1.7.2`)
-* `node['splunk']['package']['build']` - Corresponding build number (`dc318a6952c4`)
+* `node['splunk']['package']['version']` - Major version to install (`8.1.8`)
+* `node['splunk']['package']['build']` - Corresponding build number (`39da583cc695`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.53.0'
+version          '2.54.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -39,7 +39,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-8.1.7.2-dc318a6952c4' }
+  let(:splunk_file) { 'splunkforwarder-8.1.8-39da583cc695' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -54,7 +54,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-8.1.7.2-dc318a6952c4-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-8.1.8-39da583cc695-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
When I did the last upgrade to 8.1.7.2, I tested the full package install but I forgot to test the UF.  As it turns out, since the UF wasn't affected by the log4j vulns, they didn't release an 8.1.7.2 version of it. For the UF, there was 8.1.7 and then 8.1.8.  Updating the default to 8.1.8 so consumers of the UF don't have to override the version attribute to get a successful chef run.