### PR TITLE
Updated dependencies post release, fix lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Max: 8
+
 Metrics/MethodLength:
   Max: 40
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 rvm:
 - 2.5.5
 - 2.6.5
-- 2.7.1
+- 2.7.5
 addons:
   apt:
     packages:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
 # Going forward, these should be updated to the latest versions immediately post release
-chefspec_version = '= 9.3.1'
+chefspec_version = if Bundler.current_ruby.on_25?
+                 '= 9.2.1'
+               else
+                 '= 9.3.1'
+               end
 
 foodcritic_version = '= 16.3.0'
 rubocop_version = '= 1.25.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
 # Going forward, these should be updated to the latest versions immediately post release
-chefspec_version = '= 9.2.1'
+chefspec_version = '= 9.3.1'
 
 foodcritic_version = '= 16.3.0'
-rubocop_version = '= 0.81.0'
+rubocop_version = '= 1.25.0'
 
 chef_vault_version = '~> 4.0'
 
@@ -13,7 +13,7 @@ chef_version = if Bundler.current_ruby.on_25?
                elsif Bundler.current_ruby.on_26?
                  '= 15.8.23'
                else
-                 '= 16.6.14'
+                 '= 16.17.18'
                end
 
 gem 'berkshelf'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,7 +80,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider :virtualbox do |vb|
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'off']
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'off']
-    vb.customize ['modifyvm', :id, '--memory', 256]
+    vb.customize ['modifyvm', :id, '--memory', 384]
   end
 
   config.vm.define :chef do |cfg|

--- a/libraries/conf_template.rb
+++ b/libraries/conf_template.rb
@@ -64,7 +64,7 @@ module CernerSplunk
           proc { value }
         end
 
-        def self.vault(coordinate:, default_coords: nil, pick_context: nil, node:, **_)
+        def self.vault(coordinate:, node:, default_coords: nil, pick_context: nil, **_)
           proc { CernerSplunk::DataBag.load coordinate, secret: node['splunk']['data_bag_secret'], default: default_coords, pick_context: pick_context }
         end
 

--- a/libraries/databag.rb
+++ b/libraries/databag.rb
@@ -6,7 +6,7 @@
 require 'chef/dsl/data_query'
 require 'chef-vault'
 
-module CernerSplunk #:nodoc:
+module CernerSplunk # :nodoc:
   # This module has methods and classes dealing with databags
   module DataBag
     extend Chef::DSL::DataQuery

--- a/libraries/lwrp.rb
+++ b/libraries/lwrp.rb
@@ -16,7 +16,7 @@ module CernerSplunk
   module LWRP
     # Change a list of monitors to a hash of stanzas for writing to a config file
     def self.convert_monitors(monitors, default_index = nil, base = {})
-      all_stanzas = monitors.inject(base) do |stanzas, element|
+      monitors.inject(base) do |stanzas, element|
         type = element['type'] || element[:type] || 'monitor'
         path = element['path'] || element[:path]
 
@@ -32,14 +32,13 @@ module CernerSplunk
         end
         stanzas
       end
-      all_stanzas
     end
 
     # RESOURCE: extend CernerSplunk::LWRP::DelayableAttribute unless defined? delayable_attribute
     #
     # Extension of the Resource DSL, defines an attribute that can be set upfront or can be calculated at convergence time.
     module DelayableAttribute
-      def delayable_attribute(attr_name, validation = {}) # rubocop:disable Metrics/CyclomaticComplexity
+      def delayable_attribute(attr_name, validation = {})
         class_eval(<<-SHIM, __FILE__, __LINE__ + 1)
           def #{attr_name}(arg=nil,&block)
             _set_or_return_#{attr_name}(arg,block)

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -14,9 +14,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
   NODE_TYPE ||= lambda do |symbol|
     throw 'Symbol should not be nil' unless symbol
     throw "Cannot set type '#{symbol}', already set '#{node.default['splunk']['node_type']}'" if node.default['splunk']['node_type']
-    if node['splunk']['free_license']
-      throw "Cannot use the Splunk #{symbol} recipe with the free license" unless %i[forwarder server].include? symbol
-    end
+    throw "Cannot use the Splunk #{symbol} recipe with the free license" if node['splunk']['free_license'] && !(%i[forwarder server].include? symbol)
     node.default['splunk']['node_type'] = symbol.to_sym
   end
 
@@ -126,7 +124,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
 
   # Determine if we need to use the splunk start command instead of systemctl
   # https://docs.splunk.com/Documentation/Splunk/8.1.3/Admin/RunSplunkassystemdservice#Upgrade_considerations_for_systemd
-  def self.use_splunk_start_command?(node, previous_splunk_version) # rubocop:disable Metrics/CyclomaticComplexity
+  def self.use_splunk_start_command?(node, previous_splunk_version)
     return false unless ::File.exist?(node['splunk']['systemd_file_location'])
     return false if previous_splunk_version.nil?
 

--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -13,7 +13,7 @@ require 'mixlib/archive'
 module CernerSplunk
   # Utilities to use with the splunk_app resource/provider
   class SplunkApp
-    def self.merge_hashes(*hashes)
+    def self.merge_hashes(*hashes) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       hashes.collect(&:keys).flatten.uniq.each_with_object({}) do |app_name, result|
         app_hash = {}
 
@@ -233,8 +233,8 @@ class Chef
         fail "Downloaded tarball for #{new_resource.app} does not contain a version in app.conf!" unless tar_version.version
 
         # If we specify an expected version (see warning in should download), the tar version must match exactly OR the expected version is the base version of the (prerelease) tar version
-        if expected_version.version && tar_version != expected_version
-          fail "Expected version #{expected_version} does not match tar version #{tar_version} for #{new_resource.app}" unless expected_version.type == :base && tar_version.base == expected_version.base
+        if expected_version.version && tar_version != expected_version && !(expected_version.type == :base && tar_version.base == expected_version.base) # rubocop:disable Style/IfUnlessModifier
+          fail "Expected version #{expected_version} does not match tar version #{tar_version} for #{new_resource.app}"
         end
         # If the exact version is already installed, NOOP
         return false if tar_version == installed_version

--- a/libraries/splunk_password.rb
+++ b/libraries/splunk_password.rb
@@ -10,7 +10,7 @@ module CernerSplunk
   # Encrypts the password before writing into config files. As of now all the passwords
   # needs to be XORed except for the sslPassword. The boolean
   # parameter xor controls the XOR logic.
-  def self.splunk_encrypt_password(plain_text, splunk_secret, xor = true)
+  def self.splunk_encrypt_password(plain_text, splunk_secret, xor)
     # Prevent double encrypting values
     return plain_text if plain_text.start_with? '$1$', '$7$'
 
@@ -23,13 +23,13 @@ module CernerSplunk
         pwd.zip(xorkey).map { |c1, c2| c1 ^ c2 }.pack('c*')
       end || plain_text
 
-    '$1$' + Base64.encode64(CernerSplunk::RC4.new(rc4key).encrypt("#{password}\0")).strip!
+    "$1$#{Base64.encode64(CernerSplunk::RC4.new(rc4key).encrypt("#{password}\0")).strip!}"
   end
 
   # Decrypts the splunk passwords. As of now the encrypted passwords needs to be XORed
   # to retrieve the plain_text for every password except the sslPassword.
   # The boolean parameter xor controls the XOR logic.
-  def self.splunk_decrypt_password(encryp_password, splunk_secret, xor = true)
+  def self.splunk_decrypt_password(encryp_password, splunk_secret, xor)
     rc4key = splunk_secret.strip[0..15]
     pwd = CernerSplunk::RC4.new(rc4key).decrypt(Base64.decode64(encryp_password.sub('$1$', ''))).chomp("\0")
 

--- a/libraries/splunk_template.rb
+++ b/libraries/splunk_template.rb
@@ -17,11 +17,11 @@ class Chef
       include Chef::Mixin::Securable
       extend CernerSplunk::LWRP::DelayableAttribute unless defined? delayable_attribute
 
-      use_provider_resolver = defined?(Chef::ProviderResolver) == 'constant' && Chef::ProviderResolver.class == Class
+      use_provider_resolver = defined?(Chef::ProviderResolver) == 'constant' && Class.instance_of?(Chef::ProviderResolver.class)
 
       provides :splunk_template, (use_provider_resolver ? {} : { on_platforms: :all })
 
-      def initialize(name, run_context = nil) # rubocop:disable Metrics/CyclomaticComplexity
+      def initialize(name, run_context = nil)
         super
 
         # If there's no run_context, there's nothing we can do here

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.56.0'
+version          '2.55.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.54.0'
+version          '2.56.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/_configure_indexes.rb
+++ b/recipes/_configure_indexes.rb
@@ -71,9 +71,8 @@ index_stanzas = config.inject({}) do |result, (stanza, index_config)|
       hash['thawedPath'] = "$SPLUNK_DB/#{dir_name}/thaweddb" unless hash['thawedPath']
       hash['tstatsHomePath'] = "#{base_path}/#{dir_name}/datamodel_summary" if volume && !hash['tstatsHomePath'] && !no_gentstat
     end
-    if is_master && !index_flags['noRepFactor']
-      hash['repFactor'] = 'auto' unless hash['repFactor']
-    end
+
+    hash['repFactor'] = 'auto' if is_master && !index_flags['noRepFactor'] && !hash['repFactor']
   end
 
   result[stanza] = hash

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -33,8 +33,8 @@ include_recipe 'cerner_splunk::_restart_marker'
 # Under systemd, starting or restarting the service allows the chef run to continue
 # before Splunk is finished initializing.  Need to wait a bit to let it fully start
 # before we run any other commands.
-execute 'sleep-10' do
-  command 'sleep 10'
+execute 'sleep-15' do
+  command 'sleep 15'
   action :nothing
   only_if { ::File.exist? node['splunk']['systemd_file_location'] }
 end
@@ -48,7 +48,7 @@ service 'splunk' do
   supports status: true, start: true, stop: true
   start_command splunk_start_command if CernerSplunk.use_splunk_start_command? node, previous_splunk_version
   notifies :delete, 'file[splunk-marker]', :immediately
-  notifies :run, 'execute[sleep-10]', :immediately
+  notifies :run, 'execute[sleep-15]', :immediately
 end
 
 # This service definition is used for restarting splunk when the run is over
@@ -58,7 +58,7 @@ service 'splunk-restart' do
   supports status: true, restart: true
   only_if { ::File.exist? CernerSplunk.restart_marker_file }
   notifies :delete, 'file[splunk-marker]', :immediately
-  notifies :run, 'execute[sleep-10]', :immediately
+  notifies :run, 'execute[sleep-15]', :immediately
 end
 
 ruby_block 'splunk-delayed-restart' do

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -25,8 +25,8 @@ ruby_block 'update-initd-file' do
     file = Chef::Util::FileEdit.new(init_file_path)
     file.insert_line_after_match(/^RETVAL=\d$/, ulimit_command)
     file.insert_line_after_match(/^#{ulimit_command}$/, "USER=#{node['splunk']['user']}")
-    file.search_file_replace(%r{"[$\w\/]+\/bin\/splunk" start --no-prompt --answer-yes}, "su - ${USER} -c '\\0'")
-    file.search_file_replace(%r{"[$\w\/]+\/bin\/splunk" (stop|restart|status)}, "su - ${USER} -c '\\0'")
+    file.search_file_replace(%r{"[$\w/]+/bin/splunk" start --no-prompt --answer-yes}, "su - ${USER} -c '\\0'")
+    file.search_file_replace(%r{"[$\w/]+/bin/splunk" (stop|restart|status)}, "su - ${USER} -c '\\0'")
     file.write_file
   end
   only_if { File.exist?(init_file_path) }

--- a/spec/unit/libraries/splunk_password_spec.rb
+++ b/spec/unit/libraries/splunk_password_spec.rb
@@ -13,7 +13,7 @@ describe 'CernerSplunk::splunk_password' do
       let(:password) { '$1$RhLQiUyG3Qc7' }
 
       it 'does not re-encrypt it again' do
-        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
+        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret, true)
         expect(encrypted).to eq(password)
       end
     end
@@ -21,7 +21,7 @@ describe 'CernerSplunk::splunk_password' do
       let(:password) { '$7$password' }
 
       it 'does not re-encrypt it again' do
-        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret)
+        encrypted = CernerSplunk.splunk_encrypt_password(password, splunk_secret, true)
         expect(encrypted).to eq(password)
       end
     end
@@ -29,8 +29,8 @@ describe 'CernerSplunk::splunk_password' do
 
   describe '.splunk_decrypt_password' do
     context 'when decrypting an encrypted password' do
-      subject { CernerSplunk.splunk_encrypt_password(password, splunk_secret) }
-      let(:decrypted_password) { CernerSplunk.splunk_decrypt_password(subject, splunk_secret) }
+      subject { CernerSplunk.splunk_encrypt_password(password, splunk_secret, true) }
+      let(:decrypted_password) { CernerSplunk.splunk_decrypt_password(subject, splunk_secret, true) }
 
       it 'results in the original value' do
         expect(decrypted_password).to eq(password)


### PR DESCRIPTION
Updating dependencies post-release.  I was having issues with some of the vagrant tests running locally, so I also increased the sleep time to wait for the service to restart and I increased the available memory on the vagrant boxes.  They perform much better now.

Since Chef 16.17.18 embeds ruby 2.7.5, I also bumped up the ruby version for the travis builds from 2.7.1 to 2.7.5 to match.