### PR TITLE
Update vagrant to use centos-stream-8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ def chef_defaults(chef, name, environment = 'splunk_server')
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'bento/centos-8.3'
+  config.vm.box = 'bento/centos-stream-8'
 
   if Vagrant.has_plugin? 'vagrant-berkshelf'
     config.berkshelf.enabled = false


### PR DESCRIPTION
I was attempting to test something but all the vagrant boxes were failing to start due to the following error:
```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

if command -v dnf; then
  dnf -y install curl
else
  yum -y install curl
fi

Stdout from the command:

/bin/dnf
CentOS Linux 8 - AppStream                       79  B/s |  38  B     00:00    

Stderr from the command:

Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```

Searching for the error, I ran across [this site](https://techglimpse.com/failed-metadata-repo-appstream-centos-8/) that indicates centos-8 reached EOL at the end of 2021, so the associated public repositories have been shut down.  To resolve the issue, I'm updating the vagrant boxes to use the newer centos-stream-8 image.