### PR TITLE
Fix app permissions from environment file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,7 +84,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.define :chef do |cfg|
-    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk -v 4.7.73'
+    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk -v 4.13.3'
 
     if ENV['KNIFE_ONLY']
       cfg.vm.provision :shell, inline: 'cd /vagrant/vagrant_repo; mv nodes .nodes.bak', privileged: false

--- a/libraries/splunk_app.rb
+++ b/libraries/splunk_app.rb
@@ -302,7 +302,7 @@ class Chef
       end
 
       def manage_metaconf
-        permissions = new_resource.permissions
+        permissions = new_resource.permissions.dup
         permissions.each do |stanza, hash|
           hash.each do |key, values|
             permissions[stanza][key] = values.map { |right, role| "#{right} : [ #{[*role].join(', ')} ]" }.join(', ') if values.is_a?(Hash)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.55.0'
+version          '2.55.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -4,7 +4,21 @@
   "default_attributes": {
     "splunk": {
       "apps": {
-        "bag": "cerner_splunk/cluster-apps-vagrant:search_head"
+        "bag": "cerner_splunk/cluster-apps-vagrant:search_head",
+        "another_awesome_app": {
+          "files": {
+            "app.conf": {
+              "ui": {
+                "is_visible": "1",
+                "label": "Another Awesome Splunk App"
+              }
+            }
+          },
+          "permissions": {
+            "": { "access": { "read": "*", "write": "*" } },
+            "viewstates": { "access": { "read": "*", "write": "*" } }
+          }
+        }
       },
       "logs": {
         "splunkd": {


### PR DESCRIPTION
When defining an app hash in an environment file, the resulting object is a Chef::Node::ImmutableMash. Within the splunk_app resource, we then attempt to modify that hash and it results in the following error:

```
==> s_standalone:     ================================================================================
==> s_standalone:     Error executing action `create` on resource 'splunk_app[foo]'
==> s_standalone:     ================================================================================
==> s_standalone:     
==> s_standalone:     Chef::Exceptions::ImmutableAttributeModification
==> s_standalone:     ------------------------------------------------
==> s_standalone:     Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'
==> s_standalone:     
==> s_standalone:     Cookbook Trace: (most recent call first)
==> s_standalone:     ----------------------------------------
==> s_standalone:     /var/chef/cache/cookbooks/cerner_splunk/libraries/splunk_app.rb:308:in `block (2 levels) in manage_metaconf'
==> s_standalone:     /var/chef/cache/cookbooks/cerner_splunk/libraries/splunk_app.rb:307:in `each'
==> s_standalone:     /var/chef/cache/cookbooks/cerner_splunk/libraries/splunk_app.rb:307:in `block in manage_metaconf'
==> s_standalone:     /var/chef/cache/cookbooks/cerner_splunk/libraries/splunk_app.rb:306:in `each'
==> s_standalone:     /var/chef/cache/cookbooks/cerner_splunk/libraries/splunk_app.rb:306:in `manage_metaconf'
==> s_standalone:     /var/chef/cache/cookbooks/cerner_splunk/libraries/splunk_app.rb:157:in `action_create'
==> s_standalone:     
==> s_standalone:     Resource Declaration:
==> s_standalone:     ---------------------
==> s_standalone:     # In /var/chef/cache/cookbooks/cerner_splunk/recipes/_configure_apps.rb
==> s_standalone:     
==> s_standalone:      24:   splunk_app app_name do
==> s_standalone:      25:     apps_dir "#{node['splunk']['home']}/etc/apps"
==> s_standalone:      26:     action app_data['remove'] ? :remove : :create
==> s_standalone:      27:     url download_data['url']
==> s_standalone:      28:     version download_data['version']
==> s_standalone:      29:     local app_data['local']
==> s_standalone:      30:     files app_data['files']
==> s_standalone:      31:     lookups app_data['lookups']
==> s_standalone:      32:     permissions app_data['permissions']
==> s_standalone:      33:     notifies :touch, 'file[splunk-marker]', :immediately
==> s_standalone:      34:   end
==> s_standalone:      35: end
```

To avoid this problem, I added code to clone the object prior to making any modifications.  I also added a test case to the s_standalone vagrant setup to cover this scenario.  We didn't notice this in the past because when the app configurations come from a databag, they are either a ChefUtils::Mash or just a plain ruby Hash.

As an aside, I also bumped up the chefdk version on the vagrant setup to the latest in the 4.x line.  Some of the older versions are getting to be deprecated.