### PR TITLE
Update to support Chef 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 - 2.5.5
 - 2.6.5
 - 2.7.5
+- 3.0.3
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.5.5
 - 2.6.5
 - 2.7.5
 - 3.0.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 chefspec_version = if Bundler.current_ruby.on_25?
                  '= 9.2.1'
                else
-                 '= 9.3.1'
+                 '= 9.3.3'
                end
 
 foodcritic_version = '= 16.3.0'
@@ -16,8 +16,10 @@ chef_version = if Bundler.current_ruby.on_25?
                  '= 14.13.11'
                elsif Bundler.current_ruby.on_26?
                  '= 15.8.23'
-               else
+               elsif Bundler.current_ruby.on_26?
                  '= 16.17.18'
+               else
+                  '= 17.10.0'
                end
 
 gem 'berkshelf'

--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,18 @@
 source 'https://rubygems.org'
 
 # Going forward, these should be updated to the latest versions immediately post release
-chefspec_version = if Bundler.current_ruby.on_25?
-                 '= 9.2.1'
-               else
-                 '= 9.3.3'
-               end
-
+chefspec_version = '= 9.3.1'
 foodcritic_version = '= 16.3.0'
 rubocop_version = '= 1.25.0'
 
 chef_vault_version = '~> 4.0'
 
-chef_version = if Bundler.current_ruby.on_25?
-                 '= 14.13.11'
-               elsif Bundler.current_ruby.on_26?
+chef_version = if Bundler.current_ruby.on_26?
                  '= 15.8.23'
-               elsif Bundler.current_ruby.on_26?
+               elsif Bundler.current_ruby.on_27?
                  '= 16.17.18'
                else
-                  '= 17.10.0'
+                 '= 17.10.0'
                end
 
 gem 'berkshelf'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Requirements
 * Chef 14+
 * Chef 15+
 * Chef 16+
+* Chef 17+
 
 Getting your logs into Splunk
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Based on the work done by [BBY Solutions](https://github.com/bestbuycom/splunk_c
 Requirements
 ------------
 * Red Hat Enterprise / CentOS 6.7+ / CentOS 7.0+ / CentOS 8.0+ / Windows Server 2008+ (forwarder only) or Ubuntu LTS 12.04+
-* Chef 14+
 * Chef 15+
 * Chef 16+
 * Chef 17+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ def network(config, name, splunk_password = true)
 end
 
 def chef_defaults(chef, name, environment = 'splunk_server')
-  chef.version = '16'
+  chef.version = '17'
   chef.arguments = "--chef-license accept"
   chef.environment = environment
   chef.chef_server_url = "http://#{@chefip}:4000/"
@@ -80,7 +80,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider :virtualbox do |vb|
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'off']
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'off']
-    vb.customize ['modifyvm', :id, '--memory', 384]
+    vb.customize ['modifyvm', :id, '--memory', 1152]
   end
 
   config.vm.define :chef do |cfg|

--- a/libraries/splunk_template.rb
+++ b/libraries/splunk_template.rb
@@ -17,9 +17,7 @@ class Chef
       include Chef::Mixin::Securable
       extend CernerSplunk::LWRP::DelayableAttribute unless defined? delayable_attribute
 
-      use_provider_resolver = defined?(Chef::ProviderResolver) == 'constant' && Class.instance_of?(Chef::ProviderResolver.class)
-
-      provides :splunk_template, (use_provider_resolver ? {} : { on_platforms: :all })
+      provides :splunk_template
 
       def initialize(name, run_context = nil)
         super

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '2.56.0'
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 14', '< 18'
+chef_version     '>= 15', '< 18'
 
 depends          'chef-vault', '> 3.0'
 depends          'ulimit', '~> 1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,12 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.55.1'
+version          '2.56.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 14', '< 17'
+chef_version     '>= 14', '< 18'
 
 depends          'chef-vault', '> 3.0'
 depends          'ulimit', '~> 1.0'


### PR DESCRIPTION
Considering Chef 16 will be EOL on Nov. 30, we need to add support for at least Chef 17.  I looked around a bit, and Chef 18 will likely require some additional changes so I didn't opt to dive into that quite yet.  I don't think any of the changes I made would actually cause things to stop working on Chef 14, but considering how old it is I feel like we're safe dropping support for it.  Keeping support for the last 3 major versions feels reasonable.

All the spec tests passed and I spun up all the boxes with vagrant and everything seemed to work fine.

https://docs.chef.io/versions/#deprecated-products-and-versions