### PR TITLE
Stop Splunk before package upgrades

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.56.0'
+version          '2.56.1'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'


### PR DESCRIPTION
We got reports of occasional issues of failed chef runs when upgrading the splunk packages.  During the splunk-start command it would fail due to:
```
ERROR: In order to migrate, Splunkd must not be running.
```

I couldn't reproduce it via the vagrant tests, but the splunk docs do indicate to stop the splunk service before upgrading the package so it seems like a good idea to include that in the cookbook.