### PR TITLE
v2.57.0 - Chef 18 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.6.5
 - 2.7.5
 - 3.0.3
+- 3.1.2
 addons:
   apt:
     packages:

--- a/Berksfile
+++ b/Berksfile
@@ -1,17 +1,6 @@
 source 'https://supermarket.chef.io'
+solver :ruby
 
 metadata
-
-case RUBY_VERSION
-when '2.1.6'
-  # build-essential >=8.0.0 requires chef 12.5+
-  cookbook 'build-essential', '< 8.0.0'
-  # mingw >=2.0.0 requires chef 12.5+
-  cookbook 'mingw', '< 2.0.0'
-  # ohai >=5.0.0 requires chef 12.5+
-  cookbook 'ohai', '< 5.0.0'
-  # windows >=3.0.0 requires chef 12.5+
-  cookbook 'windows', '< 3.0.0'
-end
 
 cookbook 'cerner_splunk_test', path: 'spec/cookbooks/cerner_splunk_test'

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,12 @@ rubocop_version = '= 1.25.0'
 
 chef_vault_version = '~> 4.0'
 
-chef_version = if Bundler.current_ruby.on_26?
-                 '= 15.8.23'
-               elsif Bundler.current_ruby.on_27?
+chef_version = if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0') && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
                  '= 16.17.18'
-               else
+               elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0') && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1.0')
                  '= 17.10.0'
+               elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+                 '= 18.1.0'
                end
 
 gem 'berkshelf'

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Based on the work done by [BBY Solutions](https://github.com/bestbuycom/splunk_c
 
 Requirements
 ------------
-* Red Hat Enterprise / CentOS 6.7+ / CentOS 7.0+ / CentOS 8.0+ / Windows Server 2008+ (forwarder only) or Ubuntu LTS 12.04+
-* Chef 15+
+* Red Hat Enterprise / CentOS 6.7+ / CentOS 7.0+ / CentOS 8.0+ / Windows Server 2008+ (forwarder only) or Ubuntu LTS 16.04+
 * Chef 16+
 * Chef 17+
+* Chef 18+
 
 Getting your logs into Splunk
 -----------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,8 +55,12 @@ def network(config, name, splunk_password = true)
 end
 
 def chef_defaults(chef, name, environment = 'splunk_server')
-  chef.version = '17'
-  chef.arguments = "--chef-license accept"
+  chef.version = '18'
+  if ENV['CHEF_DEBUG'] # if you want chef-client debug output
+    chef.arguments = "--chef-license accept -l debug" 
+  else
+    chef.arguments = "--chef-license accept"
+  end
   chef.environment = environment
   chef.chef_server_url = "http://#{@chefip}:4000/"
   chef.validation_key_path = 'vagrant_repo/fake-key.pem'
@@ -80,11 +84,12 @@ Vagrant.configure('2') do |config|
   config.vm.provider :virtualbox do |vb|
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'off']
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'off']
-    vb.customize ['modifyvm', :id, '--memory', 1152]
+    vb.customize ['modifyvm', :id, '--memory', 1536]
   end
 
   config.vm.define :chef do |cfg|
-    cfg.vm.provision :shell, inline: 'rpm -q chefdk || curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P chefdk -v 4.13.3'
+    # update VERSION to take newer packages (current version is the lastest that still has chef-client 16) https://docs.chef.io/release_notes_workstation/
+    cfg.vm.provision :shell, inline: 'VERSION="21.4.365" && yum install -y https://packages.chef.io/files/stable/chef-workstation/${VERSION}/el/8/chef-workstation-${VERSION}-1.el7.x86_64.rpm'
 
     if ENV['KNIFE_ONLY']
       cfg.vm.provision :shell, inline: 'cd /vagrant/vagrant_repo; mv nodes .nodes.bak', privileged: false
@@ -95,7 +100,7 @@ Vagrant.configure('2') do |config|
     # We then need to run through any ruby files as well
     # We use berks to upload everything here as well, as we could be on VPN :)
     cfg.vm.provision :shell, inline: <<-'SCRIPT'.gsub(/^\s+/, ''), privileged: false
-      export PATH=$PATH:/opt/chefdk/bin:/opt/chefdk/embedded/bin
+      export PATH=$PATH:/opt/chef-workstation/bin:/opt/chef-workstation/embedded/bin
       nohup chef-zero -H 0.0.0.0 -p 4000 2>&1 > /dev/null &
       cd /vagrant/vagrant_repo
       gem install bundler
@@ -127,7 +132,7 @@ Vagrant.configure('2') do |config|
         fi
       done
       cd "$HOME"
-      netstat -nl | grep -q :5000 || nohup /opt/chefdk/embedded/bin/ruby -run -e httpd "$HOME/app_service" -p5000 2>&1 > /dev/null &
+      netstat -nl | grep -q :5000 || nohup /opt/chef-workstation/embedded/bin/ruby -run -e httpd "$HOME/app_service" -p5000 2>&1 > /dev/null &
       sleep 10
     SCRIPT
 
@@ -284,6 +289,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :f_debian do |cfg|
     cfg.vm.box = 'bento/ubuntu-16.04'
+    cfg.vm.boot_timeout = 600 # was timing out for WSL
 
     cfg.vm.provision :chef_client do |chef|
       chef_defaults chef, :f_debian, 'splunk_standalone'

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -9,11 +9,12 @@ Running with Vagrant
   * `vagrant provision chef` - Will only package splunk apps if they're not already packaged.
   * `REGEN_APPS=1 vagrant provision chef` - Will repackage all apps.
 * You can speed up repeated provisioning attempts by mirroring the Splunk package downloads locally:
-  1. Download the needed splunk packages locally, in a directory structure mirroring that of download.splunk.com
+  * Download the needed splunk packages locally, in a directory structure mirroring that of download.splunk.com
     * You can find URLs for Splunk packages at the [Splunk download page](http://splunk.com/download)
   * Host the root of your mirrored structure on port 8080 using a lightweight HTTP server such as the node package [http-server](https://npmjs.org/package/http-server)
   * Un-comment the `splunk-mirrors` role in the Vagrant file. (Do not check in this modification of your Vagrantfile)
 * `vagrant-omnibus` installer currently requires internet access to function.
+* To debug the output of `chef-client`, run `CHEF_DEBUG=1 vagrant up <vm_name>` for a given VM, or `CHEF_DEBUG=1 vagrant up /c1_.*/` for all the nodes in a cluster.
 
 **Note**:
 If you want to set up the vagrant cluster to use the license pools defined in the [license pool hash](databags.md#license-pool-hash) databag, add the `configure_guids` recipe to the run_list on the cluster slave (to update the GUIDs on these slaves to predefined values) and update the `license_uri` attribute in the cluster-vagrant databag item to point to the license master (_https://192.168.56.30:8089_).

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,18 +5,17 @@ maintainer       'Healthe Intent Infrastructure - Cerner Innovation, Inc.'
 maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.56.1'
+
+version          '2.57.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'
 
-chef_version     '>= 15', '< 18'
+chef_version     '>= 16', '< 19'
 
-depends          'chef-vault', '> 3.0'
 depends          'ulimit', '~> 1.0'
 depends          'line', '~> 2.1'
 
 supports         'redhat', '>= 6.7'
-supports         'ubuntu', '>= 12.04'
+supports         'ubuntu', '>= 16.04'
 supports         'windows', '>= 6.1'

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -33,8 +33,8 @@ include_recipe 'cerner_splunk::_restart_marker'
 # Under systemd, starting or restarting the service allows the chef run to continue
 # before Splunk is finished initializing.  Need to wait a bit to let it fully start
 # before we run any other commands.
-execute 'sleep-15' do
-  command 'sleep 15'
+chef_sleep 'sleep-45' do
+  seconds 45
   action :nothing
   only_if { ::File.exist? node['splunk']['systemd_file_location'] }
 end
@@ -48,7 +48,7 @@ service 'splunk' do
   supports status: true, start: true, stop: true
   start_command splunk_start_command if CernerSplunk.use_splunk_start_command? node, previous_splunk_version
   notifies :delete, 'file[splunk-marker]', :immediately
-  notifies :run, 'execute[sleep-15]', :immediately
+  notifies :sleep, 'chef_sleep[sleep-45]', :immediately
 end
 
 # This service definition is used for restarting splunk when the run is over
@@ -58,7 +58,7 @@ service 'splunk-restart' do
   supports status: true, restart: true
   only_if { ::File.exist? CernerSplunk.restart_marker_file }
   notifies :delete, 'file[splunk-marker]', :immediately
-  notifies :run, 'execute[sleep-15]', :immediately
+  notifies :sleep, 'chef_sleep[sleep-45]', :immediately
 end
 
 ruby_block 'splunk-delayed-restart' do


### PR DESCRIPTION
**NOTE:** There are internal links to Jiras that only some will have access to.

This is part of a project where I am working on uplifting all CWx (OHAI) nodes to use Chef 18 ([Jira](https://jira3.cerner.com/browse/CWXTIAUTO-16337)).

During initial testing I saw that the `execute 'sleep-15'` resource wasn't long enough for the splunk pid to start and failing to change the admin password (`execute 'change-admin-password`). Posted my findings [in this Jira](https://jira3.cerner.com/browse/CWXTIAUTO-18531), but essential changed the resource from `execute` to `chef_sleep` ([for Chef 15.5+](https://docs.chef.io/resources/chef_sleep/)) and upped the time to 45 seconds which allowed for all tests to pass.

I also updated the chefdk to the new chef workstation as chefdk has been depreciated for a while now. The `vagrant up chef` and `vagrant provision chef` commands still work as before.

### Removed
* Chef 15 support
* Ubuntu 12.04 support

### Vagrant Log Files
**NOTE:** I was unable to get the `f_win2012r2` box to provision, it came up and timed out. Even tried turning off my firewall.

[vagrant_chef.log](https://github.com/cerner/cerner_splunk/files/10503506/vagrant_chef.log)
[vagrant_s1_s2_cluster.log](https://github.com/cerner/cerner_splunk/files/10503513/vagrant_s1_s2_cluster.log)
[vagrant_c1_cluster.log](https://github.com/cerner/cerner_splunk/files/10503514/vagrant_c1_cluster.log)
[vagrant_c2_cluster.log](https://github.com/cerner/cerner_splunk/files/10503517/vagrant_c2_cluster.log)
[vagrant_f_debian.log](https://github.com/cerner/cerner_splunk/files/10503521/vagrant_f_debian.log)
[vagrant_f_heavy.log](https://github.com/cerner/cerner_splunk/files/10503525/vagrant_f_heavy.log)
[vagrant_f_default.log](https://github.com/cerner/cerner_splunk/files/10503526/vagrant_f_default.log)
[vagrant_s_standalone.log](https://github.com/cerner/cerner_splunk/files/10503527/vagrant_s_standalone.log)
[vagrant_s_license.log](https://github.com/cerner/cerner_splunk/files/10503528/vagrant_s_license.log)
