### PR TITLE
Add an ignore attribute to allow installing 2 splunk instances.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.require_version '>= 2.2.5'
   s2_search:    { ip: '192.168.56.36', hostname: 's2.search.splunk', ports: { 8017 => 8000, 8107 => 8089 } },
   s2_slave1:    { ip: '192.168.56.37', hostname: 's2.slave01.splunk', ports: { 8018 => 8000, 8108 => 8089 } },
   s2_slave2:    { ip: '192.168.56.38', hostname: 's2.slave02.splunk', ports: { 8019 => 8000, 8109 => 8089 } },
+  sf_standalone:{ ip: '192.168.56.39', hostname: 'splunk3', ports: { 8020 => 8000, 8110 => 8089 } },
   f_default:    { ip: '192.168.56.50', hostname: 'default.forward', ports: { 9090 => 8089 } },
   f_debian:     { ip: '192.168.56.51', hostname: 'debian.forward', ports: { 9091 => 8089 } },
   f_heavy:      { ip: '192.168.56.52', hostname: 'heavy.forward', ports: { 9092 => 8089 } },
@@ -265,9 +266,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :s_standalone do |cfg|
     cfg.vm.provision :chef_client do |chef|
-      chef_defaults chef, :s_standalone, 'splunk_standalone'
+#      chef_defaults chef, :s_standalone, 'splunk_standalone'
+      chef_defaults chef, :s_standalone, 'splunkf_standalone'
       chef.add_recipe 'cerner_splunk_test::install_libarchive'
-      chef.add_recipe 'cerner_splunk::server'
+#    chef.add_recipe 'cerner_splunk::server'
+     chef.add_recipe 'cerner_splunk::forwarder'
     end
     network cfg, :s_standalone
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,6 @@ Vagrant.require_version '>= 2.2.5'
   s2_search:    { ip: '192.168.56.36', hostname: 's2.search.splunk', ports: { 8017 => 8000, 8107 => 8089 } },
   s2_slave1:    { ip: '192.168.56.37', hostname: 's2.slave01.splunk', ports: { 8018 => 8000, 8108 => 8089 } },
   s2_slave2:    { ip: '192.168.56.38', hostname: 's2.slave02.splunk', ports: { 8019 => 8000, 8109 => 8089 } },
-  sf_standalone:{ ip: '192.168.56.39', hostname: 'splunk3', ports: { 8020 => 8000, 8110 => 8089 } },
   f_default:    { ip: '192.168.56.50', hostname: 'default.forward', ports: { 9090 => 8089 } },
   f_debian:     { ip: '192.168.56.51', hostname: 'debian.forward', ports: { 9091 => 8089 } },
   f_heavy:      { ip: '192.168.56.52', hostname: 'heavy.forward', ports: { 9092 => 8089 } },

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -266,11 +266,13 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :s_standalone do |cfg|
     cfg.vm.provision :chef_client do |chef|
-#      chef_defaults chef, :s_standalone, 'splunk_standalone'
-      chef_defaults chef, :s_standalone, 'splunkf_standalone'
+      chef_defaults chef, :s_standalone, 'splunk_standalone'
+# This is used to test installing the forwarder ontop of a node that already has splunk installed. Only have 1 chef_defaults line active.
+#      chef_defaults chef, :s_standalone, 'splunkf_standalone'
       chef.add_recipe 'cerner_splunk_test::install_libarchive'
-#    chef.add_recipe 'cerner_splunk::server'
-     chef.add_recipe 'cerner_splunk::forwarder'
+      chef.add_recipe 'cerner_splunk::server'
+# This is used to test installing the forwarder ontop of a node that already has splunk installed. Only have splunk_server OR forwarder active.
+#      chef.add_recipe 'cerner_splunk::forwarder'
     end
     network cfg, :s_standalone
   end

--- a/attributes/_configure.rb
+++ b/attributes/_configure.rb
@@ -43,7 +43,7 @@ default['splunk']['boot_start_args'] =
     when 6
       '-systemd-managed 0'
     when 7, 8
-      '-systemd-managed 1 -systemd-unit-file-name splunk'
+      '-systemd-managed 1'
     else
       '-systemd-managed 0'
     end
@@ -53,5 +53,5 @@ default['splunk']['boot_start_args'] =
 
 # Default systemd file location based on default systemd unit file name
 default['splunk']['systemd_file_location'] = '/etc/systemd/system/splunk.service'
-
+default['splunk']['systemd_unit_file_name'] = 'splunk'
 default['splunk']['config']['sslPassword'] = 'password'

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -39,3 +39,6 @@ default['splunk']['package']['file_suffix'] =
       '-x86-release.msi'
     end
   end
+
+# Ignore another splunk artifact installed on a node. This is for when you want to install the universal forwarder alongisde an instance of Splunk Enterprise.
+default['splunk']['ignore_already_installed_instance'] = false

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -50,6 +50,8 @@ Configurable (with defaults)
 * `node['splunk']['is_cloud']` - Set this attribute to `true` on cloud instances for Search Head Cluster (SHC). (`false`)
 * `node['splunk']['boot_start_args']` - Set splunk enabled boot-start arguments here. (` -systemd-managed 0`)
 * `node['splunk']['logs']` - Specify the contents of log-local.cfg, to override the default settings of Splunk's internal logging.
+* `node['splunk']['ignore_already_installed_instance']` - Set this attribute to `true` to allow the installation of a universal fowarder along side a full splunk installation. This will need to be a completely separate chef run.
+* `node['splunk']['systemd_unit_file_name']` - Allows the changing of the systemd unit file name.
 
 Non-configurable (defaults)
 ----------------------------

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -18,6 +18,7 @@ Running with Vagrant
 **Note**:
 If you want to set up the vagrant cluster to use the license pools defined in the [license pool hash](databags.md#license-pool-hash) databag, add the `configure_guids` recipe to the run_list on the cluster slave (to update the GUIDs on these slaves to predefined values) and update the `license_uri` attribute in the cluster-vagrant databag item to point to the license master (_https://192.168.56.30:8089_).
 After you spin up the cluster slaves you will have to restart the cluster master to bring the cluster to a stable state. While spinning up the cluster slaves, they are re-assigned with different GUIDS by the `configure_guids` recipe which requires a restart (this restart can take a while to complete). Cluster master is restarted so that it can identify the new GUIDS.
+To test installing a Universal Forwarder along side a Splunk Enterprise installation, use the s_standalone vagrant instance. There are 2 comments in the Vagrantfile that replace the environment and recipe that is ran against the box. Run the default config first and then comment out the two lines mentioned and run `vagrant provsion chef s_standalone` to install the universal forwarder. 
 
 # Spinning up a Search Head Cluster in Vagrant
 

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -144,9 +144,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
       return 'SplunkForwarder' if package_base_name == 'splunkforwarder'
       return 'Splunkd' if package_base_name == 'splunk'
     end
-      return systemd_unit_file_name
-    #return 'splunkforwarder' if package_base_name == 'splunkforwarder'
-    #'splunk'
+    return systemd_unit_file_name
   end
 
   # Validates that the splunk.secret file either does not exist or has the same value that's currently configured.

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -103,7 +103,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
   # Returns the installed package name based on platform and package base name.
   # Written because Windows is dumb
   def self.installed_package_name(platform_family, package_base_name, systemd_unit_file_name)
-    return package_base_name unless systemd_unit_file_name != '' unless platform_family == 'windows'
+    return package_base_name unless platform_family == 'windows'
 
     # Windows package names
     return 'Splunk Enterprise' if package_base_name == 'splunk'

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -102,7 +102,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
 
   # Returns the installed package name based on platform and package base name.
   # Written because Windows is dumb
-  def self.installed_package_name(platform_family, package_base_name, _systemd_unit_file_name)
+  def self.installed_package_name(platform_family, package_base_name)
     return package_base_name unless platform_family == 'windows'
 
     # Windows package names

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -102,8 +102,8 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
 
   # Returns the installed package name based on platform and package base name.
   # Written because Windows is dumb
-  def self.installed_package_name(platform_family, package_base_name)
-    return package_base_name unless platform_family == 'windows'
+  def self.installed_package_name(platform_family, package_base_name, systemd_unit_file_name)
+    return package_base_name unless systemd_unit_file_name != '' unless platform_family == 'windows'
 
     # Windows package names
     return 'Splunk Enterprise' if package_base_name == 'splunk'
@@ -139,13 +139,14 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
   end
 
   # Returns the Splunk service name based on platform and package name
-  def self.splunk_service_name(platform_family, package_base_name)
+  def self.splunk_service_name(platform_family, package_base_name, systemd_unit_file_name)
     if platform_family == 'windows'
       return 'SplunkForwarder' if package_base_name == 'splunkforwarder'
       return 'Splunkd' if package_base_name == 'splunk'
     end
-
-    'splunk'
+      return systemd_unit_file_name
+    #return 'splunkforwarder' if package_base_name == 'splunkforwarder'
+    #'splunk'
   end
 
   # Validates that the splunk.secret file either does not exist or has the same value that's currently configured.

--- a/libraries/recipe_utils.rb
+++ b/libraries/recipe_utils.rb
@@ -102,7 +102,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
 
   # Returns the installed package name based on platform and package base name.
   # Written because Windows is dumb
-  def self.installed_package_name(platform_family, package_base_name, systemd_unit_file_name)
+  def self.installed_package_name(platform_family, package_base_name, _systemd_unit_file_name)
     return package_base_name unless platform_family == 'windows'
 
     # Windows package names
@@ -144,7 +144,7 @@ module CernerSplunk # rubocop:disable Metrics/ModuleLength
       return 'SplunkForwarder' if package_base_name == 'splunkforwarder'
       return 'Splunkd' if package_base_name == 'splunk'
     end
-    return systemd_unit_file_name
+    systemd_unit_file_name
   end
 
   # Validates that the splunk.secret file either does not exist or has the same value that's currently configured.

--- a/recipes/_generate_password.rb
+++ b/recipes/_generate_password.rb
@@ -8,11 +8,14 @@
 
 return if node['splunk']['free_license'] && node['splunk']['node_type'] != :forwarder
 
-return if node['splunk']['ignore_already_installed_instance'] == true
-
 require 'securerandom'
 
-password_file = File.join node['splunk']['external_config_directory'], 'password'
+# For a node that has multiple splunk instances, create a separate password file.
+password_file = if node['splunk']['ignore_already_installed_instance'] == true
+                  File.join node['splunk']['external_config_directory'], 'password_forwarder'
+                else
+                  File.join node['splunk']['external_config_directory'], 'password'
+                end
 
 old_password = File.exist?(password_file) ? File.read(password_file) : 'changeme'
 

--- a/recipes/_generate_password.rb
+++ b/recipes/_generate_password.rb
@@ -11,7 +11,7 @@ return if node['splunk']['free_license'] && node['splunk']['node_type'] != :forw
 require 'securerandom'
 
 # For a node that has multiple splunk instances, create a separate password file.
-password_file = if node['splunk']['ignore_already_installed_instance'] == true
+password_file = if node['splunk']['ignore_already_installed_instance']
                   File.join node['splunk']['external_config_directory'], 'password_forwarder'
                 else
                   File.join node['splunk']['external_config_directory'], 'password'

--- a/recipes/_generate_password.rb
+++ b/recipes/_generate_password.rb
@@ -8,6 +8,8 @@
 
 return if node['splunk']['free_license'] && node['splunk']['node_type'] != :forwarder
 
+return if node['splunk']['ignore_already_installed_instance'] == true
+
 require 'securerandom'
 
 password_file = File.join node['splunk']['external_config_directory'], 'password'

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -18,7 +18,7 @@ node.default['splunk']['package']['url'] =
 node.default['splunk']['home'] = CernerSplunk.splunk_home(node['platform_family'], node['kernel']['machine'], nsp['base_name'])
 node.default['splunk']['cmd'] = CernerSplunk.splunk_command(node)
 
-service = CernerSplunk.splunk_service_name(node['platform_family'], nsp['base_name'])
+service = CernerSplunk.splunk_service_name(node['platform_family'], nsp['base_name'], node['splunk']['systemd_unit_file_name'])
 
 manifest_missing = proc { ::Dir.glob("#{node['splunk']['home']}/#{node['splunk']['package']['name']}-*").empty? }
 

--- a/recipes/_migrate_forwarder.rb
+++ b/recipes/_migrate_forwarder.rb
@@ -24,7 +24,7 @@ ruby_block 'backup-splunk-artifacts' do
 end
 
 package opposite_package_name do
-  package_name CernerSplunk.installed_package_name(node['platform_family'], opposite_package_name)
+  package_name CernerSplunk.installed_package_name(node['platform_family'], opposite_package_name, systemd_unit_file_name)
   action :remove
 end
 

--- a/recipes/_migrate_forwarder.rb
+++ b/recipes/_migrate_forwarder.rb
@@ -24,7 +24,7 @@ ruby_block 'backup-splunk-artifacts' do
 end
 
 package opposite_package_name do
-  package_name CernerSplunk.installed_package_name(node['platform_family'], opposite_package_name, systemd_unit_file_name)
+  package_name CernerSplunk.installed_package_name(node['platform_family'], opposite_package_name)
   action :remove
 end
 

--- a/recipes/_migrate_forwarder.rb
+++ b/recipes/_migrate_forwarder.rb
@@ -10,7 +10,7 @@ require 'fileutils'
 opposite_package_name = CernerSplunk.opposite_package_name(node['splunk']['package']['base_name'])
 
 service 'splunk' do
-  service_name CernerSplunk.splunk_service_name(node['platform_family'], opposite_package_name)
+  service_name CernerSplunk.splunk_service_name(node['platform_family'], opposite_package_name, node['splunk']['systemd_unit_file_name'])
   action :stop
 end
 

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -13,7 +13,8 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 package_version = Gem::Version.new(node['splunk']['package']['version'])
 command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
 command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
-command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if package_version >= Gem::Version.new('7.2.2')
+command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if package_version >= Gem::Version.new('7.2.2') if node['platform_version'].to_i != 6
+command += " #{node['splunk']['boot_start_args']}" if package_version >= Gem::Version.new('7.2.2') if node['platform_version'].to_i == 6
 
 execute command do
   not_if { platform_family?('windows') }

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -13,8 +13,8 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 package_version = Gem::Version.new(node['splunk']['package']['version'])
 command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
 command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
-command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if package_version >= Gem::Version.new('7.2.2') if node['platform_version'].to_i != 6
-command += " #{node['splunk']['boot_start_args']}" if package_version >= Gem::Version.new('7.2.2') if node['platform_version'].to_i == 6
+command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if node['platform_version'].to_i != 6 && (package_version >= Gem::Version.new('7.2.2'))
+command += " #{node['splunk']['boot_start_args']}" if node['platform_version'].to_i == 6 && (package_version >= Gem::Version.new('7.2.2'))
 
 execute command do
   not_if { platform_family?('windows') }

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -11,11 +11,11 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 
 # We want to always ensure that the boot-start script is in place on non-windows platforms
 package_version = Gem::Version.new(node['splunk']['package']['version'])
-command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}"
+command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
 command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
 #####
 #command += 
-command += " #{node['splunk']['boot_start_args']}" if package_version >= Gem::Version.new('7.2.2')
+command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if package_version >= Gem::Version.new('7.2.2')
 
 execute command do
   not_if { platform_family?('windows') }

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -57,10 +57,22 @@ end
 
 # We then start splunk. In the future, the other resource should be here instead of this clumsy notification
 # but we'd need to refactor the determination of the service name away from the _install recipe.
-ruby_block 'start-splunk' do
-  block { true }
-  notifies :start, 'service[splunk]', :immediately
+
+ruby_block 'start-splunk-service' do
+  if node['splunk']['ignore_already_installed_instance'] == true
+    block { true }
+    notifies :start, 'service[splunkforwarder]', :immediately
+  else
+    block { true }
+    notifies :start, 'service[splunk]', :immediately
+  end
 end
+
+
+# ruby_block 'start-splunk' do
+#   block { true }
+#   notifies :start, 'service[splunk]', :immediately
+# end
 
 # The first time splunk is started on linux using chef the .pid file is owned by root which causes issues.
 pid_file = "#{node['splunk']['home']}/var/run/splunk/splunkd.pid"

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -11,8 +11,10 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 
 # We want to always ensure that the boot-start script is in place on non-windows platforms
 package_version = Gem::Version.new(node['splunk']['package']['version'])
-command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
+command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}"
 command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
+#####
+#command += 
 command += " #{node['splunk']['boot_start_args']}" if package_version >= Gem::Version.new('7.2.2')
 
 execute command do
@@ -57,22 +59,10 @@ end
 
 # We then start splunk. In the future, the other resource should be here instead of this clumsy notification
 # but we'd need to refactor the determination of the service name away from the _install recipe.
-
-ruby_block 'start-splunk-service' do
-  if node['splunk']['ignore_already_installed_instance'] == true
-    block { true }
-    notifies :start, 'service[splunkforwarder]', :immediately
-  else
-    block { true }
-    notifies :start, 'service[splunk]', :immediately
-  end
+ruby_block 'start-splunk' do
+  block { true }
+  notifies :start, 'service[splunk]', :immediately
 end
-
-
-# ruby_block 'start-splunk' do
-#   block { true }
-#   notifies :start, 'service[splunk]', :immediately
-# end
 
 # The first time splunk is started on linux using chef the .pid file is owned by root which causes issues.
 pid_file = "#{node['splunk']['home']}/var/run/splunk/splunkd.pid"

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -13,8 +13,6 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 package_version = Gem::Version.new(node['splunk']['package']['version'])
 command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
 command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
-#####
-#command += 
 command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if package_version >= Gem::Version.new('7.2.2')
 
 execute command do

--- a/recipes/_start.rb
+++ b/recipes/_start.rb
@@ -13,8 +13,8 @@ restart_flag = !(File.exist?(init_file_path) && File.readlines(init_file_path).g
 package_version = Gem::Version.new(node['splunk']['package']['version'])
 command = "#{node['splunk']['cmd']} enable boot-start -user #{node['splunk']['user']}"
 command += " -group #{node['splunk']['group']}" if package_version >= Gem::Version.new('7.3.0')
-command += " #{node['splunk']['boot_start_args']} -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if node['platform_version'].to_i != 6 && (package_version >= Gem::Version.new('7.2.2'))
-command += " #{node['splunk']['boot_start_args']}" if node['platform_version'].to_i == 6 && (package_version >= Gem::Version.new('7.2.2'))
+command += " #{node['splunk']['boot_start_args']}" if package_version >= Gem::Version.new('7.2.2')
+command += " -systemd-unit-file-name #{node['splunk']['systemd_unit_file_name']}" if node['platform_version'].to_i > 6 && (package_version >= Gem::Version.new('7.2.2'))
 
 execute command do
   not_if { platform_family?('windows') }

--- a/recipes/forwarder.rb
+++ b/recipes/forwarder.rb
@@ -11,7 +11,7 @@ instance_exec :forwarder, &CernerSplunk::NODE_TYPE
 node.default['splunk']['package']['base_name'] = 'splunkforwarder'
 node.default['splunk']['package']['download_group'] = 'universalforwarder'
 
-fail 'Different Splunk artifact already installed on node. Failing as an unsupported install' if CernerSplunk.separate_splunk_installed?(node) && node['splunk']['ignore_already_installed_instance'] == false
+fail 'Different Splunk artifact already installed on node. Failing as an unsupported install' if CernerSplunk.separate_splunk_installed?(node) && !node['splunk']['ignore_already_installed_instance']
 
 ## Recipes
 include_recipe 'cerner_splunk::_install'

--- a/recipes/forwarder.rb
+++ b/recipes/forwarder.rb
@@ -11,7 +11,7 @@ instance_exec :forwarder, &CernerSplunk::NODE_TYPE
 node.default['splunk']['package']['base_name'] = 'splunkforwarder'
 node.default['splunk']['package']['download_group'] = 'universalforwarder'
 
-fail 'Different Splunk artifact already installed on node. Failing as an unsupported install' if CernerSplunk.separate_splunk_installed?(node)
+fail 'Different Splunk artifact already installed on node. Failing as an unsupported install' if CernerSplunk.separate_splunk_installed?(node) &&  node['splunk']['ignore_already_installed_instance'] == false
 
 ## Recipes
 include_recipe 'cerner_splunk::_install'

--- a/recipes/forwarder.rb
+++ b/recipes/forwarder.rb
@@ -11,7 +11,7 @@ instance_exec :forwarder, &CernerSplunk::NODE_TYPE
 node.default['splunk']['package']['base_name'] = 'splunkforwarder'
 node.default['splunk']['package']['download_group'] = 'universalforwarder'
 
-fail 'Different Splunk artifact already installed on node. Failing as an unsupported install' if CernerSplunk.separate_splunk_installed?(node) &&  node['splunk']['ignore_already_installed_instance'] == false
+fail 'Different Splunk artifact already installed on node. Failing as an unsupported install' if CernerSplunk.separate_splunk_installed?(node) && node['splunk']['ignore_already_installed_instance'] == false
 
 ## Recipes
 include_recipe 'cerner_splunk::_install'

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -44,7 +44,8 @@
         }
       },
       "data_bag_secret": "/vagrant/vagrant_repo/alternative_encrypted_data_bag_secret",
-      "mgmt_interface": "eth1"
+      "mgmt_interface": "eth1",
+      "ignore_already_installed_instance" : true
     }
   }
 }

--- a/vagrant_repo/environments/splunk_standalone.json
+++ b/vagrant_repo/environments/splunk_standalone.json
@@ -44,8 +44,7 @@
         }
       },
       "data_bag_secret": "/vagrant/vagrant_repo/alternative_encrypted_data_bag_secret",
-      "mgmt_interface": "eth1",
-      "ignore_already_installed_instance" : true
+      "mgmt_interface": "eth1"
     }
   }
 }

--- a/vagrant_repo/environments/splunkf_standalone.json
+++ b/vagrant_repo/environments/splunkf_standalone.json
@@ -3,8 +3,8 @@
   "description": "Environment for the Splunk Standalone server and a separate universal forwarder.",
   "default_attributes": {
     "splunk": {
-      "boot_start_args": "-systemd-managed 1 -systemd-unit-file-name splunkforwarder",
-      "systemd_file_location": "etc/systemd/system/splunkforwarder.service",
+      "systemd_file_location": "/etc/systemd/system/splunkforwarder.service",
+      "systemd_unit_file_name": "splunkforwarder",
       "ignore_already_installed_instance" : true,
       "apps": {
         "CONFIG-CSSP_splunk": {

--- a/vagrant_repo/environments/splunkf_standalone.json
+++ b/vagrant_repo/environments/splunkf_standalone.json
@@ -1,0 +1,27 @@
+{
+  "name": "splunkf_standalone",
+  "description": "Environment for the Splunk Standalone server and a separate universal forwarder.",
+  "default_attributes": {
+    "splunk": {
+      "boot_start_args": "-systemd-managed 1 -systemd-unit-file-name splunkforwarder",
+      "systemd_file_location": "etc/systemd/system/splunkforwarder.service",
+      "ignore_already_installed_instance" : true,
+      "apps": {
+        "CONFIG-CSSP_splunk": {
+          "files": {
+            "web.conf": {
+              "settings": {
+                "mgmtHostPort": 8088
+              }
+            },
+            "deploymentclient.conf": {
+              "target-broker:deploymentServer": {
+                "targetUri": "CERNCSECSPLNKDS00.northamerica.cerner.net:8089"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/vagrant_repo/environments/splunkf_standalone.json
+++ b/vagrant_repo/environments/splunkf_standalone.json
@@ -16,7 +16,7 @@
             },
             "deploymentclient.conf": {
               "target-broker:deploymentServer": {
-                "targetUri": "CERNCSECSPLNKDS00.northamerica.cerner.net:8089"
+                "targetUri": "test.net:8089"
               }
             }
           }


### PR DESCRIPTION
Add an ignore attribute to allow installing 2 splunk instances.



Added ignore_already_installed_instance attribute default false.
Added ^ to the forwarder recipe.
Added ignore_already_installed_instance as true to s_standalone environment.

Tested this by running chef and s_standalone normally and then running cerner_splunk::forwarder on s_standalone.

https://gist.github.com/HCarr64/2e7fbc6f22b51157d457d133e77b043e

Vagrant Tests:
chef & s_standalone: https://gist.github.com/HCarr64/2e7fbc6f22b51157d457d133e77b043e
s1 & s2: https://gist.github.com/HCarr64/9066d1cb23795eebc8c10b9495392e8f
c1: https://gist.github.com/HCarr64/b65791855eb841f1628dc98d58f67e97
c2: https://gist.github.com/HCarr64/20a2efde542782cf460eef83c5e5dc87 I've never been able to get c2_newnode to run correctly.
f: https://gist.github.com/HCarr64/ec895cc9ee2501dad13ff0aa7c742dc8
s_license: https://gist.github.com/HCarr64/5f98316122449745d1b6f0029f69e757