### PR TITLE
update default splunk version to 9.0.5

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -13,8 +13,8 @@ default['splunk']['external_config_directory'] =
     '/etc/splunk'
   end
 
-default['splunk']['package']['version'] = '9.0.2'
-default['splunk']['package']['build'] = '17e00c557dc1'
+default['splunk']['package']['version'] = '9.0.5'
+default['splunk']['package']['build'] = 'e9494146ae5c'
 default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']
@@ -22,7 +22,12 @@ default['splunk']['package']['file_suffix'] =
   case node['platform_family']
   when 'rhel', 'fedora'
     if node['kernel']['machine'] == 'x86_64'
+      # linux rpms of splunk/UF before 9.0.5 are a differently named package.
+      if default['splunk']['package']['version'] >= '9.0.5'
+        '.x86_64.rpm'
+      else
       '-linux-2.6-x86_64.rpm'
+      end
     else
       '.i386.rpm'
     end

--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -23,7 +23,8 @@ default['splunk']['package']['file_suffix'] =
   when 'rhel', 'fedora'
     if node['kernel']['machine'] == 'x86_64'
       # linux rpms of splunk/UF before 9.0.5 are a differently named package.
-      if default['splunk']['package']['version'] >= '9.0.5'
+      package_version = Gem::Version.new(node['splunk']['package']['version'])
+      if package_version >= Gem::Version.new('9.0.5')
         '.x86_64.rpm'
       else
       '-linux-2.6-x86_64.rpm'

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -19,8 +19,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`9.0.2`)
-* `node['splunk']['package']['build']` - Corresponding build number (`17e00c557dc1`)
+* `node['splunk']['package']['version']` - Major version to install (`9.0.5.1`)
+* `node['splunk']['package']['build']` - Corresponding build number (`52d49260b188`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -19,8 +19,8 @@ Configurable (with defaults)
   * `node['splunk']['monitors'][]['type']` - Type of stanza (`monitor`). See [inputs.conf][] for stanzas.
   * `node['splunk']['monitors'][][???]` - Other attributes for an inputs.conf stanza. See [inputs.conf][]
 * `node['splunk']['cleanup']` - Determines whether the recipe should attempt to clean up the old forwarder install (`true`)
-* `node['splunk']['package']['version']` - Major version to install (`9.0.5.1`)
-* `node['splunk']['package']['build']` - Corresponding build number (`52d49260b188`)
+* `node['splunk']['package']['version']` - Major version to install (`9.0.5`)
+* `node['splunk']['package']['build']` - Corresponding build number (`e9494146ae5c`)
 * `node['splunk']['package']['base_url']` - Base download path (`https://download.splunk.com/products`)
 * `node['splunk']['package']['base_name']` - Name of the package to install (`splunkforwarder`/`splunk`)
 * `node['splunk']['package']['name']` - Name of the package being installed (`"#{node['splunk']['package']['base_name']}-#{node['splunk']['package']['version']}-#{node['splunk']['package']['build']}"`)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 
-version          '2.58.0'
+version          '2.59.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/spec/unit/recipes/_install_spec.rb
+++ b/spec/unit/recipes/_install_spec.rb
@@ -41,7 +41,7 @@ describe 'cerner_splunk::_install' do
 
   let(:windows) { nil }
 
-  let(:splunk_file) { 'splunkforwarder-9.0.2-17e00c557dc1' }
+  let(:splunk_file) { 'splunkforwarder-9.0.5-e9494146ae5c' }
   let(:splunk_filepath) { "/var/chef/cache/#{splunk_file}.txt" }
 
   before do
@@ -56,7 +56,7 @@ describe 'cerner_splunk::_install' do
     allow(File).to receive(:exist?).with('/opt/splunkforwarder/ftr').and_return(ftr_exists)
 
     allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-9.0.2-17e00c557dc1-*').and_return(glob)
+    allow(Dir).to receive(:glob).with('/opt/splunkforwarder/splunkforwarder-9.0.5-e9494146ae5c-*').and_return(glob)
 
     # Stub alt separator for windows in Ruby 1.9.3
     stub_const('::File::ALT_SEPARATOR', '/')


### PR DESCRIPTION
Update default version to 9.0.5.

The linux rpm of splunk 9.0.5 and above have a different style of package name. Hence the additional changes in [attributes/_install.rb.
](https://github.com/cerner/cerner_splunk/compare/stable...HCarr64:9.0.5.1?expand=1#diff-9734e70eb8fa648b230fc1392386e7d52a9d1237d6c422b881adee80645b4739)

Other than the random bug I get regarding cerner_splunk::_generate_password hanging, all vagrant checks passed.
Rspec passed.