### PR TITLE
Move file_suffix settings

### DIFF
--- a/attributes/_install.rb
+++ b/attributes/_install.rb
@@ -18,33 +18,6 @@ default['splunk']['package']['build'] = 'e9494146ae5c'
 default['splunk']['is_cloud'] = false
 default['splunk']['package']['base_url'] = 'https://download.splunk.com/products'
 default['splunk']['package']['platform'] = node['os']
-default['splunk']['package']['file_suffix'] =
-  case node['platform_family']
-  when 'rhel', 'fedora'
-    if node['kernel']['machine'] == 'x86_64'
-      # linux rpms of splunk/UF before 9.0.5 are a differently named package.
-      package_version = Gem::Version.new(node['splunk']['package']['version'])
-      if package_version >= Gem::Version.new('9.0.5')
-        '.x86_64.rpm'
-      else
-      '-linux-2.6-x86_64.rpm'
-      end
-    else
-      '.i386.rpm'
-    end
-  when 'debian'
-    if node['kernel']['machine'] == 'x86_64'
-      '-linux-2.6-amd64.deb'
-    else
-      '-linux-2.6-intel.deb'
-    end
-  when 'windows'
-    if node['kernel']['machine'] == 'x86_64'
-      '-x64-release.msi'
-    else
-      '-x86-release.msi'
-    end
-  end
 
 # Ignore another splunk artifact installed on a node. This is for when you want to install the universal forwarder alongisde an instance of Splunk Enterprise.
 default['splunk']['ignore_already_installed_instance'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'splunk@cerner.com'
 license          'Apache-2.0'
 description      'Installs/Configures Splunk Servers and Forwarders'
 
-version          '2.59.0'
+version          '2.60.0'
 
 source_url       'https://github.com/cerner/cerner_splunk'
 issues_url       'https://github.com/cerner/cerner_splunk/issues'

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -12,6 +12,33 @@ end
 
 # Attributes
 node.default['splunk']['package']['name'] = "#{nsp['base_name']}-#{nsp['version']}-#{nsp['build']}"
+node.default['splunk']['package']['file_suffix'] =
+  case node['platform_family']
+  when 'rhel', 'fedora'
+    if node['kernel']['machine'] == 'x86_64'
+      # linux rpms of splunk/UF before 9.0.5 are a differently named package.
+      package_version = Gem::Version.new(node['splunk']['package']['version'])
+      if package_version >= Gem::Version.new('9.0.5')
+        '.x86_64.rpm'
+      else
+      '-linux-2.6-x86_64.rpm'
+      end
+    else
+      '.i386.rpm'
+    end
+  when 'debian'
+    if node['kernel']['machine'] == 'x86_64'
+      '-linux-2.6-amd64.deb'
+    else
+      '-linux-2.6-intel.deb'
+    end
+  when 'windows'
+    if node['kernel']['machine'] == 'x86_64'
+      '-x64-release.msi'
+    else
+      '-x86-release.msi'
+    end
+  end
 node.default['splunk']['package']['file_name'] = "#{nsp['name']}#{nsp['file_suffix']}"
 node.default['splunk']['package']['url'] =
   "#{nsp['base_url']}/#{nsp['download_group']}/releases/#{nsp['version']}/#{nsp['platform']}/#{nsp['file_name']}"


### PR DESCRIPTION
https://stackoverflow.com/a/23338940

Attribute hierarchy was preventing backwards compatibility when pulling cerner_splunk into our internal roles cookbook. Moving file_suffix logic from attributes to recipes fixed this issue. Tested with vagrant tests and pointing internal roles cookbook to local cerner_splunk.